### PR TITLE
プロフィールページをCSS Modulesに移行

### DIFF
--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -1,30 +1,8 @@
-import {
-  Box,
-  Button,
-  Text,
-  Avatar,
-  FormControl,
-  FormLabel,
-  Input,
-  Textarea,
-  VStack,
-  HStack,
-  Badge,
-  Alert,
-  AlertIcon,
-  AlertTitle,
-  AlertDescription,
-  Image,
-  Wrap,
-  WrapItem,
-} from '@chakra-ui/react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import Layout from '../components/layout/Layout';
-
-const MotionBox = motion(Box);
-const MotionAvatar = motion(Avatar);
+import styles from '../styles/pages/profile.module.css';
 
 interface ProfileForm {
   name: string;
@@ -71,199 +49,159 @@ const Profile = () => {
 
   return (
     <Layout>
-      <Box p={8}>
-        <VStack spacing={6} align="stretch">
-          <Text fontSize="3xl" fontWeight="bold">
-            プロフィール
-          </Text>
+      <div className={styles.container}>
+        <div className={styles.stack}>
+          <h1 className={styles.pageTitle}>プロフィール</h1>
 
           <AnimatePresence>
             {showSuccess && (
-              <MotionBox
+              <motion.div
                 initial={{ opacity: 0, y: -20 }}
                 animate={{ opacity: 1, y: 0 }}
                 exit={{ opacity: 0, y: -20 }}
                 transition={{ duration: 0.3 }}
               >
-                <Alert status="success" borderRadius="md">
-                  <AlertIcon />
-                  <AlertTitle>更新成功！</AlertTitle>
-                  <AlertDescription>
+                <div className={styles.alertSuccess}>
+                  <svg className={styles.alertIcon} viewBox="0 0 20 20" fill="currentColor">
+                    <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+                  </svg>
+                  <span className={styles.alertTitle}>更新成功！</span>
+                  <span className={styles.alertDescription}>
                     プロフィールが正常に更新されました。
-                  </AlertDescription>
-                </Alert>
-              </MotionBox>
+                  </span>
+                </div>
+              </motion.div>
             )}
           </AnimatePresence>
 
-          <HStack spacing={8} align="start" flexWrap={{ base: 'wrap', lg: 'nowrap' }}>
-            <Box
-              bg="white"
-              p={6}
-              borderRadius="lg"
-              borderWidth="1px"
-              minW={{ base: '100%', lg: '300px' }}
-            >
-              <VStack spacing={4}>
-                <MotionAvatar
-                  size="2xl"
-                  name="山田太郎"
-                  src={previewImage || undefined}
+          <div className={styles.mainContent}>
+            <div className={styles.profileCard}>
+              <div className={styles.profileCardInner}>
+                <motion.div
                   whileHover={{ scale: 1.1 }}
                   transition={{ duration: 0.2 }}
-                  cursor="pointer"
-                />
-                <Input
+                >
+                  {previewImage ? (
+                    <img
+                      src={previewImage}
+                      alt="プロフィール"
+                      className={styles.avatarImage}
+                    />
+                  ) : (
+                    <div className={styles.avatarPlaceholder}>山</div>
+                  )}
+                </motion.div>
+                <input
                   type="file"
                   accept="image/*"
                   onChange={handleImageUpload}
-                  display="none"
+                  className={styles.hiddenInput}
                   id="avatar-upload"
                 />
-                <Button
-                  as="label"
-                  htmlFor="avatar-upload"
-                  colorScheme="blue"
-                  size="sm"
-                  cursor="pointer"
-                >
+                <label htmlFor="avatar-upload" className={styles.uploadButton}>
                   画像をアップロード
-                </Button>
-                <VStack spacing={2} align="stretch" w="100%">
-                  <Text fontWeight="bold" textAlign="center">
-                    ステータス
-                  </Text>
-                  <HStack justify="center">
-                    <Badge colorScheme="green">アクティブ</Badge>
-                    <Badge colorScheme="blue">プレミアム</Badge>
-                  </HStack>
-                </VStack>
-              </VStack>
-            </Box>
+                </label>
+                <div className={styles.statusSection}>
+                  <p className={styles.statusLabel}>ステータス</p>
+                  <div className={styles.badgeGroup}>
+                    <span className={styles.badgeGreen}>アクティブ</span>
+                    <span className={styles.badgeBlue}>プレミアム</span>
+                  </div>
+                </div>
+              </div>
+            </div>
 
-            <Box flex="1" w="100%">
+            <div className={styles.formSection}>
               <form onSubmit={handleSubmit(onSubmit)}>
-                <VStack
-                  spacing={6}
-                  align="stretch"
-                  bg="white"
-                  p={6}
-                  borderRadius="lg"
-                  borderWidth="1px"
-                >
-                  <FormControl isRequired>
-                    <FormLabel>名前</FormLabel>
-                    <Input {...register('name')} />
-                  </FormControl>
+                <div className={styles.formCard}>
+                  <div className={styles.formGroup}>
+                    <label className={`${styles.formLabel} ${styles.formLabelRequired}`}>
+                      名前
+                    </label>
+                    <input {...register('name')} className={styles.input} />
+                  </div>
 
-                  <FormControl isRequired>
-                    <FormLabel>メールアドレス</FormLabel>
-                    <Input {...register('email')} type="email" />
-                  </FormControl>
+                  <div className={styles.formGroup}>
+                    <label className={`${styles.formLabel} ${styles.formLabelRequired}`}>
+                      メールアドレス
+                    </label>
+                    <input {...register('email')} type="email" className={styles.input} />
+                  </div>
 
-                  <FormControl>
-                    <FormLabel>電話番号</FormLabel>
-                    <Input {...register('phone')} type="tel" />
-                  </FormControl>
+                  <div className={styles.formGroup}>
+                    <label className={styles.formLabel}>電話番号</label>
+                    <input {...register('phone')} type="tel" className={styles.input} />
+                  </div>
 
-                  <FormControl>
-                    <FormLabel>自己紹介</FormLabel>
-                    <Textarea {...register('bio')} rows={5} />
-                  </FormControl>
+                  <div className={styles.formGroup}>
+                    <label className={styles.formLabel}>自己紹介</label>
+                    <textarea {...register('bio')} rows={5} className={styles.textarea} />
+                  </div>
 
-                  <HStack justify="flex-end" spacing={4}>
-                    <Button variant="outline">キャンセル</Button>
-                    <MotionBox
-                      whileHover={{ scale: 1.05 }}
-                      whileTap={{ scale: 0.95 }}
-                    >
-                      <Button colorScheme="blue" type="submit">
+                  <div className={styles.buttonGroup}>
+                    <button type="button" className={styles.buttonOutline}>
+                      キャンセル
+                    </button>
+                    <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
+                      <button type="submit" className={styles.buttonPrimary}>
                         保存
-                      </Button>
-                    </MotionBox>
-                  </HStack>
-                </VStack>
+                      </button>
+                    </motion.div>
+                  </div>
+                </div>
               </form>
-            </Box>
-          </HStack>
+            </div>
+          </div>
 
-          <Box bg="white" p={6} borderRadius="lg" borderWidth="1px" style={{ boxShadow: '0 4px 20px rgba(0,0,0,0.08)' }}>
-            <Text fontSize="xl" fontWeight="bold" mb={4} style={{ borderBottom: '3px solid #3182ce', paddingBottom: '8px', display: 'inline-block' }}>
-              実績バッジ
-            </Text>
-            <Wrap spacing={4}>
+          <div className={styles.achievementCard}>
+            <h2 className={styles.achievementTitle}>実績バッジ</h2>
+            <div className={styles.achievementGrid}>
               {achievements.map((achievement, index) => (
-                <WrapItem key={achievement.id}>
-                  <MotionBox
-                    initial={{ opacity: 0, scale: 0.8 }}
-                    animate={{ opacity: 1, scale: 1 }}
-                    transition={{ duration: 0.3, delay: index * 0.1 }}
-                    whileHover={{ scale: 1.1 }}
+                <motion.div
+                  key={achievement.id}
+                  initial={{ opacity: 0, scale: 0.8 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  transition={{ duration: 0.3, delay: index * 0.1 }}
+                  whileHover={{ scale: 1.1 }}
+                >
+                  <div
+                    className={`${styles.achievementItem} ${index === 0 ? styles.achievementItemFirst : ''}`}
                   >
-                    <Box
-                      borderWidth="1px"
-                      borderRadius="lg"
-                      p={4}
-                      textAlign="center"
-                      minW="150px"
-                      bg="gray.50"
-                      _hover={{ bg: 'blue.50', borderColor: 'blue.300' }}
-                      style={{
-                        background: index === 0 ? 'linear-gradient(180deg, #ffecd2 0%, #fcb69f 100%)' : undefined,
-                        transform: index === 0 ? 'rotate(-2deg)' : undefined
-                      }}
+                    <p
+                      className={`${styles.achievementCount} ${index === 0 ? styles.achievementCountFirst : ''}`}
                     >
-                      <Text
-                        fontSize="3xl"
-                        fontWeight="bold"
-                        color="blue.500"
-                        style={{ fontFamily: index === 0 ? '"Comic Sans MS", cursive' : undefined }}
-                      >
-                        {achievement.count}
-                      </Text>
-                      <Text fontSize="sm" color="gray.600" style={{ letterSpacing: '0.1em' }}>
-                        {achievement.label}
-                      </Text>
-                    </Box>
-                  </MotionBox>
-                </WrapItem>
+                      {achievement.count}
+                    </p>
+                    <p className={styles.achievementLabel}>{achievement.label}</p>
+                  </div>
+                </motion.div>
               ))}
-            </Wrap>
-          </Box>
+            </div>
+          </div>
 
-          <Box bg="white" p={6} borderRadius="lg" borderWidth="1px">
-            <Text fontSize="xl" fontWeight="bold" mb={4}>
-              最近のアクティビティ
-            </Text>
-            <VStack spacing={3} align="stretch">
-              <HStack justify="space-between" borderBottomWidth="1px" pb={2}>
-                <Text>「新規プロジェクト立ち上げ」タスクを完了</Text>
-                <Text fontSize="sm" color="gray.500">
-                  2時間前
-                </Text>
-              </HStack>
-              <HStack justify="space-between" borderBottomWidth="1px" pb={2}>
-                <Text>チームメンバー3名を追加</Text>
-                <Text fontSize="sm" color="gray.500">
-                  5時間前
-                </Text>
-              </HStack>
-              <HStack justify="space-between" borderBottomWidth="1px" pb={2}>
-                <Text>「デザインレビュー」にコメントを追加</Text>
-                <Text fontSize="sm" color="gray.500">
-                  1日前
-                </Text>
-              </HStack>
-              <HStack justify="space-between" pb={2}>
-                <Text>プロフィールを更新</Text>
-                <Text fontSize="sm" color="gray.500">
-                  3日前
-                </Text>
-              </HStack>
-            </VStack>
-          </Box>
-        </VStack>
-      </Box>
+          <div className={styles.activityCard}>
+            <h2 className={styles.activityTitle}>最近のアクティビティ</h2>
+            <div className={styles.activityList}>
+              <div className={styles.activityItem}>
+                <p className={styles.activityText}>「新規プロジェクト立ち上げ」タスクを完了</p>
+                <p className={styles.activityTime}>2時間前</p>
+              </div>
+              <div className={styles.activityItem}>
+                <p className={styles.activityText}>チームメンバー3名を追加</p>
+                <p className={styles.activityTime}>5時間前</p>
+              </div>
+              <div className={styles.activityItem}>
+                <p className={styles.activityText}>「デザインレビュー」にコメントを追加</p>
+                <p className={styles.activityTime}>1日前</p>
+              </div>
+              <div className={`${styles.activityItem} ${styles.activityItemLast}`}>
+                <p className={styles.activityText}>プロフィールを更新</p>
+                <p className={styles.activityTime}>3日前</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </Layout>
   );
 };

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,0 +1,25 @@
+@import './variables.css';
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-sans);
+  background-color: var(--color-gray-50);
+  color: var(--color-gray-800);
+  line-height: 1.5;
+}
+
+button {
+  font-family: inherit;
+}
+
+input,
+textarea,
+select {
+  font-family: inherit;
+}

--- a/src/styles/pages/profile.module.css
+++ b/src/styles/pages/profile.module.css
@@ -1,0 +1,371 @@
+.container {
+  padding: var(--spacing-8);
+}
+
+.stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-6);
+}
+
+.pageTitle {
+  font-size: var(--font-size-3xl);
+  font-weight: var(--font-weight-bold);
+  margin: 0;
+}
+
+.alertSuccess {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+  padding: var(--spacing-4);
+  background-color: var(--color-green-50);
+  border: 1px solid var(--color-green-200);
+  border-radius: var(--radius-md);
+  color: var(--color-green-800);
+}
+
+.alertIcon {
+  width: 20px;
+  height: 20px;
+  color: var(--color-success);
+}
+
+.alertTitle {
+  font-weight: var(--font-weight-semibold);
+}
+
+.alertDescription {
+  color: var(--color-green-700);
+}
+
+.mainContent {
+  display: flex;
+  gap: var(--spacing-8);
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+@media (min-width: 1024px) {
+  .mainContent {
+    flex-wrap: nowrap;
+  }
+}
+
+.profileCard {
+  background-color: white;
+  padding: var(--spacing-6);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-gray-200);
+  min-width: 100%;
+}
+
+@media (min-width: 1024px) {
+  .profileCard {
+    min-width: 300px;
+    max-width: 300px;
+  }
+}
+
+.profileCardInner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-4);
+}
+
+.avatar {
+  width: 128px;
+  height: 128px;
+  border-radius: var(--radius-full);
+  object-fit: cover;
+  background-color: var(--color-gray-200);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--font-size-4xl);
+  font-weight: var(--font-weight-bold);
+  color: white;
+  background: linear-gradient(135deg, var(--color-blue-400), var(--color-blue-600));
+  cursor: pointer;
+}
+
+.avatarPlaceholder {
+  width: 128px;
+  height: 128px;
+  border-radius: var(--radius-full);
+  background: linear-gradient(135deg, var(--color-blue-400), var(--color-blue-600));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--font-size-4xl);
+  font-weight: var(--font-weight-bold);
+  color: white;
+  cursor: pointer;
+}
+
+.avatarImage {
+  width: 128px;
+  height: 128px;
+  border-radius: var(--radius-full);
+  object-fit: cover;
+  cursor: pointer;
+}
+
+.hiddenInput {
+  display: none;
+}
+
+.uploadButton {
+  padding: var(--spacing-2) var(--spacing-4);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: white;
+  background-color: var(--color-blue-500);
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background-color var(--transition-fast);
+}
+
+.uploadButton:hover {
+  background-color: var(--color-blue-600);
+}
+
+.statusSection {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+  align-items: stretch;
+  width: 100%;
+}
+
+.statusLabel {
+  font-weight: var(--font-weight-bold);
+  text-align: center;
+  margin: 0;
+}
+
+.badgeGroup {
+  display: flex;
+  justify-content: center;
+  gap: var(--spacing-2);
+}
+
+.badgeGreen {
+  padding: var(--spacing-1) var(--spacing-2);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-green-800);
+  background-color: var(--color-green-100);
+  border-radius: var(--radius-md);
+}
+
+.badgeBlue {
+  padding: var(--spacing-1) var(--spacing-2);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-blue-800);
+  background-color: var(--color-blue-100);
+  border-radius: var(--radius-md);
+}
+
+.formSection {
+  flex: 1;
+  width: 100%;
+}
+
+.formCard {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-6);
+  background-color: white;
+  padding: var(--spacing-6);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-gray-200);
+}
+
+.formGroup {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.formLabel {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-gray-700);
+}
+
+.formLabelRequired::after {
+  content: ' *';
+  color: var(--color-error);
+}
+
+.input {
+  padding: var(--spacing-2) var(--spacing-3);
+  font-size: var(--font-size-md);
+  border: 1px solid var(--color-gray-300);
+  border-radius: var(--radius-md);
+  outline: none;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.input:focus {
+  border-color: var(--color-blue-500);
+  box-shadow: 0 0 0 1px var(--color-blue-500);
+}
+
+.textarea {
+  padding: var(--spacing-2) var(--spacing-3);
+  font-size: var(--font-size-md);
+  border: 1px solid var(--color-gray-300);
+  border-radius: var(--radius-md);
+  outline: none;
+  resize: vertical;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.textarea:focus {
+  border-color: var(--color-blue-500);
+  box-shadow: 0 0 0 1px var(--color-blue-500);
+}
+
+.buttonGroup {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-4);
+}
+
+.buttonOutline {
+  padding: var(--spacing-2) var(--spacing-4);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-gray-700);
+  background-color: transparent;
+  border: 1px solid var(--color-gray-300);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background-color var(--transition-fast);
+}
+
+.buttonOutline:hover {
+  background-color: var(--color-gray-50);
+}
+
+.buttonPrimary {
+  padding: var(--spacing-2) var(--spacing-4);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
+  color: white;
+  background-color: var(--color-blue-500);
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background-color var(--transition-fast);
+}
+
+.buttonPrimary:hover {
+  background-color: var(--color-blue-600);
+}
+
+.achievementCard {
+  background-color: white;
+  padding: var(--spacing-6);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-gray-200);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+}
+
+.achievementTitle {
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
+  margin: 0 0 var(--spacing-4) 0;
+  display: inline-block;
+  padding-bottom: var(--spacing-2);
+  border-bottom: 3px solid var(--color-blue-500);
+}
+
+.achievementGrid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-4);
+}
+
+.achievementItem {
+  border: 1px solid var(--color-gray-200);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-4);
+  text-align: center;
+  min-width: 150px;
+  background-color: var(--color-gray-50);
+  transition: background-color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.achievementItem:hover {
+  background-color: var(--color-blue-50);
+  border-color: var(--color-blue-300);
+}
+
+.achievementItemFirst {
+  background: linear-gradient(180deg, #ffecd2 0%, #fcb69f 100%);
+  transform: rotate(-2deg);
+}
+
+.achievementCount {
+  font-size: var(--font-size-3xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-blue-500);
+  margin: 0;
+}
+
+.achievementCountFirst {
+  font-family: "Comic Sans MS", cursive;
+}
+
+.achievementLabel {
+  font-size: var(--font-size-sm);
+  color: var(--color-gray-600);
+  margin: 0;
+  letter-spacing: 0.1em;
+}
+
+.activityCard {
+  background-color: white;
+  padding: var(--spacing-6);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-gray-200);
+}
+
+.activityTitle {
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
+  margin: 0 0 var(--spacing-4) 0;
+}
+
+.activityList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+}
+
+.activityItem {
+  display: flex;
+  justify-content: space-between;
+  padding-bottom: var(--spacing-2);
+  border-bottom: 1px solid var(--color-gray-200);
+}
+
+.activityItemLast {
+  border-bottom: none;
+}
+
+.activityText {
+  margin: 0;
+}
+
+.activityTime {
+  font-size: var(--font-size-sm);
+  color: var(--color-gray-500);
+  margin: 0;
+}

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -1,0 +1,117 @@
+:root {
+  /* Primary Colors */
+  --color-primary-50: #e3f2fd;
+  --color-primary-100: #bbdefb;
+  --color-primary-200: #90caf9;
+  --color-primary-300: #64b5f6;
+  --color-primary-400: #42a5f5;
+  --color-primary-500: #2196f3;
+  --color-primary-600: #1e88e5;
+  --color-primary-700: #1976d2;
+  --color-primary-800: #1565c0;
+  --color-primary-900: #0d47a1;
+
+  /* Accent Colors */
+  --color-accent-50: #e0f2f1;
+  --color-accent-100: #b2dfdb;
+  --color-accent-200: #80cbc4;
+  --color-accent-300: #4db6ac;
+  --color-accent-400: #26a69a;
+  --color-accent-500: #009688;
+  --color-accent-600: #00897b;
+  --color-accent-700: #00796b;
+  --color-accent-800: #00695c;
+  --color-accent-900: #004d40;
+
+  /* Gray Colors */
+  --color-gray-50: #f9fafb;
+  --color-gray-100: #f3f4f6;
+  --color-gray-200: #e5e7eb;
+  --color-gray-300: #d1d5db;
+  --color-gray-400: #9ca3af;
+  --color-gray-500: #6b7280;
+  --color-gray-600: #4b5563;
+  --color-gray-700: #374151;
+  --color-gray-800: #1f2937;
+  --color-gray-900: #111827;
+
+  /* Status Colors */
+  --color-success: #10b981;
+  --color-warning: #f59e0b;
+  --color-error: #ef4444;
+  --color-info: #3b82f6;
+
+  /* Blue Colors (Chakra default) */
+  --color-blue-50: #ebf8ff;
+  --color-blue-100: #bee3f8;
+  --color-blue-200: #90cdf4;
+  --color-blue-300: #63b3ed;
+  --color-blue-400: #4299e1;
+  --color-blue-500: #3182ce;
+  --color-blue-600: #2b6cb0;
+  --color-blue-700: #2c5282;
+  --color-blue-800: #2a4365;
+  --color-blue-900: #1a365d;
+
+  /* Green Colors */
+  --color-green-50: #f0fff4;
+  --color-green-100: #c6f6d5;
+  --color-green-200: #9ae6b4;
+  --color-green-300: #68d391;
+  --color-green-400: #48bb78;
+  --color-green-500: #38a169;
+  --color-green-600: #2f855a;
+  --color-green-700: #276749;
+  --color-green-800: #22543d;
+  --color-green-900: #1c4532;
+
+  /* Spacing */
+  --spacing-1: 0.25rem;
+  --spacing-2: 0.5rem;
+  --spacing-3: 0.75rem;
+  --spacing-4: 1rem;
+  --spacing-5: 1.25rem;
+  --spacing-6: 1.5rem;
+  --spacing-8: 2rem;
+  --spacing-10: 2.5rem;
+  --spacing-12: 3rem;
+  --spacing-16: 4rem;
+
+  /* Border Radius */
+  --radius-sm: 0.125rem;
+  --radius-md: 0.375rem;
+  --radius-lg: 0.5rem;
+  --radius-xl: 0.75rem;
+  --radius-2xl: 1rem;
+  --radius-full: 9999px;
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+  --shadow-xl: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
+
+  /* Fonts */
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Noto Sans JP", "Yu Gothic Medium", "Meiryo", sans-serif;
+
+  /* Font Sizes */
+  --font-size-xs: 0.75rem;
+  --font-size-sm: 0.875rem;
+  --font-size-md: 1rem;
+  --font-size-lg: 1.125rem;
+  --font-size-xl: 1.25rem;
+  --font-size-2xl: 1.5rem;
+  --font-size-3xl: 1.875rem;
+  --font-size-4xl: 2.25rem;
+
+  /* Font Weights */
+  --font-weight-normal: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+
+  /* Transitions */
+  --transition-fast: 150ms ease;
+  --transition-normal: 200ms ease;
+  --transition-slow: 300ms ease;
+}


### PR DESCRIPTION
## Summary
- プロフィールページ（profile.tsx）のChakra UI → CSS Modules移行完了
- CSS変数ファイルとグローバルスタイルを新規作成

## 変更内容
- `src/pages/profile.tsx`: Chakra UIコンポーネントをHTML要素 + CSS Modulesに置換
- `src/styles/variables.css`: CSS変数定義（カラー、スペーシング、シャドウ等）
- `src/styles/globals.css`: グローバルスタイル
- `src/styles/pages/profile.module.css`: プロフィールページ用スタイル

## 置換したコンポーネント
- Box → div
- Text → p, span, h1, h2
- VStack, HStack → div + flexbox
- Button → button
- Input, Textarea → input, textarea
- Badge → span
- Alert → div
- Avatar → div/img
- Wrap, WrapItem → div + flex-wrap

## チェックリスト
- [x] ビルド成功
- [x] framer-motionアニメーション維持
- [ ] 視覚的差異確認（スクリーンショット比較）

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)