### PR TITLE
feat: カレンダーページをCSS Modulesに移行 (#38)

### DIFF
--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -1,0 +1,56 @@
+import { useState, useRef, ReactNode } from 'react';
+import styles from '../../styles/components/tooltip.module.css';
+
+interface TooltipProps {
+  children: ReactNode;
+  label: string;
+  placement?: 'top' | 'bottom' | 'left' | 'right';
+}
+
+export const Tooltip = ({ children, label, placement = 'top' }: TooltipProps) => {
+  const [isVisible, setIsVisible] = useState(false);
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const handleMouseEnter = () => {
+    timeoutRef.current = setTimeout(() => {
+      setIsVisible(true);
+    }, 200);
+  };
+
+  const handleMouseLeave = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    setIsVisible(false);
+  };
+
+  const getPlacementClass = () => {
+    switch (placement) {
+      case 'bottom':
+        return styles.placementBottom;
+      case 'left':
+        return styles.placementLeft;
+      case 'right':
+        return styles.placementRight;
+      default:
+        return styles.placementTop;
+    }
+  };
+
+  return (
+    <div
+      className={styles.wrapper}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      {children}
+      {isVisible && (
+        <div className={`${styles.tooltip} ${getPlacementClass()}`}>
+          {label}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Tooltip;

--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -1,29 +1,10 @@
-import {
-  Box,
-  Button,
-  Text,
-  Flex,
-  Badge,
-  HStack,
-  VStack,
-  Modal,
-  ModalOverlay,
-  ModalContent,
-  ModalHeader,
-  ModalFooter,
-  ModalBody,
-  ModalCloseButton,
-  useDisclosure,
-  Avatar,
-  Tooltip,
-} from '@chakra-ui/react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useState } from 'react';
 import Layout from '../components/layout/Layout';
+import { Modal, ModalHeader, ModalBody, ModalFooter } from '../components/ui/Modal';
+import { Tooltip } from '../components/ui/Tooltip';
 import { calendarEvents } from '../lib/mockData';
-
-const MotionBox = motion(Box);
-const MotionFlex = motion(Flex);
+import styles from '../styles/pages/calendar.module.css';
 
 interface CalendarEvent {
   id: number;
@@ -35,10 +16,8 @@ interface CalendarEvent {
 
 const Calendar = () => {
   const [currentDate, setCurrentDate] = useState(new Date());
-  const [selectedEvent, setSelectedEvent] = useState<CalendarEvent | null>(
-    null
-  );
-  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [selectedEvent, setSelectedEvent] = useState<CalendarEvent | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
   const [slideDirection, setSlideDirection] = useState(1);
 
   const getDaysInMonth = (date: Date) => {
@@ -83,20 +62,42 @@ const Calendar = () => {
 
   const handleEventClick = (event: CalendarEvent) => {
     setSelectedEvent(event);
-    onOpen();
+    setIsModalOpen(true);
   };
 
-  const getEventBadgeColor = (type: string) => {
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+  };
+
+  const getEventBadgeClass = (type: string) => {
     switch (type) {
       case 'タスク':
-        return 'blue';
+        return styles.badgeBlue;
       case 'ミーティング':
-        return 'purple';
+        return styles.badgePurple;
       case '期限':
-        return 'red';
+        return styles.badgeRed;
       default:
-        return 'gray';
+        return styles.badgeGray;
     }
+  };
+
+  const getAvatarColor = (name: string) => {
+    const colors = [
+      'linear-gradient(135deg, #38b2ac, #319795)',
+      'linear-gradient(135deg, #ed64a6, #d53f8c)',
+      'linear-gradient(135deg, #a0522d, #8b4513)',
+      'linear-gradient(135deg, #9f7aea, #805ad5)',
+      'linear-gradient(135deg, #ecc94b, #d69e2e)',
+      'linear-gradient(135deg, #4299e1, #3182ce)',
+      'linear-gradient(135deg, #48bb78, #38a169)',
+      'linear-gradient(135deg, #fc8181, #f56565)',
+    ];
+    let hash = 0;
+    for (let i = 0; i < name.length; i++) {
+      hash = name.charCodeAt(i) + ((hash << 5) - hash);
+    }
+    return colors[Math.abs(hash) % colors.length];
   };
 
   const daysInMonth = getDaysInMonth(currentDate);
@@ -110,41 +111,36 @@ const Calendar = () => {
 
   return (
     <Layout>
-      <Box p={8}>
-        <VStack spacing={6} align="stretch">
-          <HStack justify="space-between">
-            <Text fontSize="3xl" fontWeight="bold">
-              カレンダー
-            </Text>
-            <HStack>
-              <Button onClick={handlePrevMonth}>前月</Button>
-              <Text fontSize="xl" fontWeight="semibold" minW="200px" textAlign="center">
+      <div className={styles.container}>
+        <div className={styles.stack}>
+          <div className={styles.header}>
+            <h1 className={styles.pageTitle}>カレンダー</h1>
+            <div className={styles.navigation}>
+              <button className={styles.navButton} onClick={handlePrevMonth}>
+                前月
+              </button>
+              <p className={styles.currentMonth}>
                 {currentDate.getFullYear()}年 {currentDate.getMonth() + 1}月
-              </Text>
-              <Button onClick={handleNextMonth}>次月</Button>
-            </HStack>
-          </HStack>
+              </p>
+              <button className={styles.navButton} onClick={handleNextMonth}>
+                次月
+              </button>
+            </div>
+          </div>
 
-          <Box borderWidth="1px" borderRadius="lg" p={4} bg="white">
-            <Flex mb={2}>
+          <div className={styles.calendarCard}>
+            <div className={styles.weekHeader}>
               {weekDays.map((day) => (
-                <Box
-                  key={day}
-                  flex="1"
-                  textAlign="center"
-                  fontWeight="bold"
-                  color="gray.600"
-                  p={2}
-                >
+                <div key={day} className={styles.weekDay}>
                   {day}
-                </Box>
+                </div>
               ))}
-            </Flex>
+            </div>
 
             <AnimatePresence mode="wait">
-              <MotionFlex
+              <motion.div
                 key={`${currentDate.getFullYear()}-${currentDate.getMonth()}`}
-                flexWrap="wrap"
+                className={styles.calendarGrid}
                 initial={{ opacity: 0, x: slideDirection * 100 }}
                 animate={{ opacity: 1, x: 0 }}
                 exit={{ opacity: 0, x: slideDirection * -100 }}
@@ -153,117 +149,91 @@ const Calendar = () => {
                 {calendarDays.map((day, index) => {
                   const events = day ? getEventsForDate(day) : [];
                   return (
-                    <Box
+                    <div
                       key={index}
-                      w="14.28%"
-                      minH="100px"
-                      p={2}
-                      borderWidth="1px"
-                      borderColor="gray.200"
-                      bg={day && isToday(day) ? 'blue.50' : 'white'}
-                      position="relative"
+                      className={`${styles.dayCell} ${day && isToday(day) ? styles.dayCellToday : ''}`}
                     >
                       {day && (
                         <>
-                          <Text
-                            fontWeight={isToday(day) ? 'bold' : 'normal'}
-                            color={isToday(day) ? 'blue.600' : 'gray.700'}
-                            fontSize="sm"
+                          <p
+                            className={`${styles.dayNumber} ${isToday(day) ? styles.dayNumberToday : ''}`}
                           >
                             {day}
-                          </Text>
-                          <VStack spacing={1} mt={2} align="stretch">
+                          </p>
+                          <div className={styles.eventList}>
                             {events.map((event) => (
                               <Tooltip
                                 key={event.id}
                                 label={`${event.title} - ${event.assignee}`}
                                 placement="top"
                               >
-                                <MotionBox
+                                <motion.div
                                   whileHover={{ scale: 1.1 }}
-                                  cursor="pointer"
                                   onClick={() => handleEventClick(event)}
                                 >
-                                  <Badge
-                                    colorScheme={getEventBadgeColor(event.type)}
-                                    fontSize="xs"
-                                    w="100%"
-                                    textAlign="center"
+                                  <span
+                                    className={`${styles.eventBadge} ${getEventBadgeClass(event.type)}`}
                                   >
                                     {event.type}
-                                  </Badge>
-                                </MotionBox>
+                                  </span>
+                                </motion.div>
                               </Tooltip>
                             ))}
-                          </VStack>
+                          </div>
                         </>
                       )}
-                    </Box>
+                    </div>
                   );
                 })}
-              </MotionFlex>
+              </motion.div>
             </AnimatePresence>
-          </Box>
-        </VStack>
+          </div>
+        </div>
 
-        <Modal
-          isOpen={isOpen}
-          onClose={onClose}
-          motionPreset="slideInBottom"
-          size="lg"
-        >
-          <ModalOverlay />
-          <ModalContent
-            as={motion.div}
-            initial={{ opacity: 0, scale: 0.9 }}
-            animate={{ opacity: 1, scale: 1 }}
-            exit={{ opacity: 0, scale: 0.9 }}
-          >
-            <ModalHeader>イベント詳細</ModalHeader>
-            <ModalCloseButton />
-            <ModalBody>
-              {selectedEvent && (
-                <VStack spacing={4} align="stretch">
-                  <Box>
-                    <Text fontWeight="bold" mb={1}>
-                      タイトル
-                    </Text>
-                    <Text>{selectedEvent.title}</Text>
-                  </Box>
-                  <Box>
-                    <Text fontWeight="bold" mb={1}>
-                      種類
-                    </Text>
-                    <Badge colorScheme={getEventBadgeColor(selectedEvent.type)}>
-                      {selectedEvent.type}
-                    </Badge>
-                  </Box>
-                  <Box>
-                    <Text fontWeight="bold" mb={1}>
-                      日付
-                    </Text>
-                    <Text>{selectedEvent.date}</Text>
-                  </Box>
-                  <Box>
-                    <Text fontWeight="bold" mb={1}>
-                      担当者
-                    </Text>
-                    <HStack>
-                      <Avatar size="sm" name={selectedEvent.assignee} />
-                      <Text>{selectedEvent.assignee}</Text>
-                    </HStack>
-                  </Box>
-                </VStack>
-              )}
-            </ModalBody>
-            <ModalFooter>
-              <Button colorScheme="blue" mr={3} onClick={onClose}>
-                閉じる
-              </Button>
-            </ModalFooter>
-          </ModalContent>
+        <Modal isOpen={isModalOpen} onClose={handleCloseModal} size="lg">
+          <ModalHeader onClose={handleCloseModal}>イベント詳細</ModalHeader>
+          <ModalBody>
+            {selectedEvent && (
+              <div className={styles.modalDetail}>
+                <div className={styles.detailSection}>
+                  <p className={styles.detailLabel}>タイトル</p>
+                  <p className={styles.detailValue}>{selectedEvent.title}</p>
+                </div>
+                <div className={styles.detailSection}>
+                  <p className={styles.detailLabel}>種類</p>
+                  <span
+                    className={`${styles.eventBadge} ${getEventBadgeClass(selectedEvent.type)}`}
+                    style={{ width: 'fit-content' }}
+                  >
+                    {selectedEvent.type}
+                  </span>
+                </div>
+                <div className={styles.detailSection}>
+                  <p className={styles.detailLabel}>日付</p>
+                  <p className={styles.detailValue}>{selectedEvent.date}</p>
+                </div>
+                <div className={styles.detailSection}>
+                  <p className={styles.detailLabel}>担当者</p>
+                  <div className={styles.assigneeRow}>
+                    <div
+                      className={styles.avatar}
+                      style={{ background: getAvatarColor(selectedEvent.assignee) }}
+                    >
+                      {selectedEvent.assignee.charAt(0)}
+                    </div>
+                    <p className={styles.detailValue}>{selectedEvent.assignee}</p>
+                  </div>
+                </div>
+              </div>
+            )}
+          </ModalBody>
+          <ModalFooter>
+            <button className={styles.buttonPrimary} onClick={handleCloseModal}>
+              閉じる
+            </button>
+          </ModalFooter>
         </Modal>
-      </Box>
+      </div>
     </Layout>
   );
 };

--- a/src/styles/components/tooltip.module.css
+++ b/src/styles/components/tooltip.module.css
@@ -1,0 +1,56 @@
+.wrapper {
+  position: relative;
+  display: inline-block;
+}
+
+.tooltip {
+  position: absolute;
+  padding: var(--spacing-2) var(--spacing-3);
+  background-color: var(--color-gray-800);
+  color: white;
+  font-size: var(--font-size-sm);
+  border-radius: var(--radius-md);
+  white-space: nowrap;
+  z-index: 1000;
+  pointer-events: none;
+  animation: fadeIn 0.15s ease-out;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.placementTop {
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-bottom: var(--spacing-2);
+}
+
+.placementBottom {
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-top: var(--spacing-2);
+}
+
+.placementLeft {
+  right: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  margin-right: var(--spacing-2);
+}
+
+.placementRight {
+  left: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  margin-left: var(--spacing-2);
+}

--- a/src/styles/pages/calendar.module.css
+++ b/src/styles/pages/calendar.module.css
@@ -1,0 +1,192 @@
+.container {
+  padding: var(--spacing-8);
+}
+
+.stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-6);
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.pageTitle {
+  font-size: var(--font-size-3xl);
+  font-weight: var(--font-weight-bold);
+  margin: 0;
+}
+
+.navigation {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+}
+
+.navButton {
+  padding: var(--spacing-2) var(--spacing-4);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-gray-700);
+  background-color: var(--color-gray-100);
+  border: 1px solid var(--color-gray-300);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background-color var(--transition-fast);
+}
+
+.navButton:hover {
+  background-color: var(--color-gray-200);
+}
+
+.currentMonth {
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-semibold);
+  min-width: 200px;
+  text-align: center;
+  margin: 0;
+}
+
+.calendarCard {
+  border: 1px solid var(--color-gray-200);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-4);
+  background-color: white;
+}
+
+.weekHeader {
+  display: flex;
+  margin-bottom: var(--spacing-2);
+}
+
+.weekDay {
+  flex: 1;
+  text-align: center;
+  font-weight: var(--font-weight-bold);
+  color: var(--color-gray-600);
+  padding: var(--spacing-2);
+}
+
+.calendarGrid {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.dayCell {
+  width: 14.28%;
+  min-height: 100px;
+  padding: var(--spacing-2);
+  border: 1px solid var(--color-gray-200);
+  position: relative;
+  background-color: white;
+}
+
+.dayCellToday {
+  background-color: var(--color-blue-50);
+}
+
+.dayNumber {
+  font-size: var(--font-size-sm);
+  color: var(--color-gray-700);
+  margin: 0;
+}
+
+.dayNumberToday {
+  font-weight: var(--font-weight-bold);
+  color: var(--color-blue-600);
+}
+
+.eventList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+  margin-top: var(--spacing-2);
+}
+
+.eventBadge {
+  padding: var(--spacing-1) var(--spacing-2);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  width: 100%;
+  text-align: center;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.badgeBlue {
+  color: var(--color-blue-800);
+  background-color: var(--color-blue-100);
+}
+
+.badgePurple {
+  color: #553c9a;
+  background-color: #e9d8fd;
+}
+
+.badgeRed {
+  color: #c53030;
+  background-color: #fed7d7;
+}
+
+.badgeGray {
+  color: var(--color-gray-700);
+  background-color: var(--color-gray-200);
+}
+
+.modalDetail {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+}
+
+.detailSection {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.detailLabel {
+  font-weight: var(--font-weight-bold);
+  margin: 0;
+}
+
+.detailValue {
+  margin: 0;
+}
+
+.assigneeRow {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+}
+
+.avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-full);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
+  color: white;
+}
+
+.buttonPrimary {
+  padding: var(--spacing-2) var(--spacing-4);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
+  color: white;
+  background-color: var(--color-blue-500);
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background-color var(--transition-fast);
+}
+
+.buttonPrimary:hover {
+  background-color: var(--color-blue-600);
+}


### PR DESCRIPTION
## Summary
- Tooltipコンポーネントを新規作成
- カレンダーページのChakra UIコンポーネントをCSS Modulesに置き換え
- useDisclosureをuseStateに置き換え
- framer-motionのアニメーションを維持

## 変更内容
- `src/components/ui/Tooltip.tsx` - 新規作成
- `src/styles/components/tooltip.module.css` - 新規作成
- `src/styles/pages/calendar.module.css` - 新規作成
- `src/pages/calendar.tsx` - CSS Modulesに移行

## Closes
- #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)