### PR TITLE
fix: カレンダーページのナビゲーションボタンを青色に修正

### DIFF
--- a/src/styles/pages/calendar.module.css
+++ b/src/styles/pages/calendar.module.css
@@ -30,16 +30,16 @@
   padding: var(--spacing-2) var(--spacing-4);
   font-size: var(--font-size-md);
   font-weight: var(--font-weight-medium);
-  color: var(--color-gray-700);
-  background-color: var(--color-gray-100);
-  border: 1px solid var(--color-gray-300);
+  color: white;
+  background-color: var(--color-blue-500);
+  border: none;
   border-radius: var(--radius-md);
   cursor: pointer;
   transition: background-color var(--transition-fast);
 }
 
 .navButton:hover {
-  background-color: var(--color-gray-200);
+  background-color: var(--color-blue-600);
 }
 
 .currentMonth {


### PR DESCRIPTION
## Summary
- カレンダーページの「前月」「次月」ボタンをChakra UIのButtonと同じ青色スタイルに修正

## 変更内容
- `.navButton` のスタイルをグレーアウトラインから青色塗りつぶしに変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)