### PR TITLE
feat: 共通レイアウトをCSS Modulesに移行 (#39)

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,27 +1,12 @@
-import {
-  Box,
-  Flex,
-  HStack,
-  Avatar,
-  Text,
-  Menu,
-  MenuButton,
-  MenuList,
-  MenuItem,
-  MenuDivider,
-  Badge,
-  IconButton,
-  useColorModeValue,
-} from '@chakra-ui/react';
 import { FiBell, FiSettings, FiLogOut, FiUser } from 'react-icons/fi';
 import { useRouter } from 'next/router';
 import { useAuth } from '../../contexts/AuthContext';
+import { Menu, MenuItem, MenuDivider } from '../ui/Menu';
+import styles from '../../styles/components/layout.module.css';
 
 export default function Header() {
   const { user, logout } = useAuth();
   const router = useRouter();
-  const bgColor = useColorModeValue('white', 'gray.800');
-  const borderColor = useColorModeValue('gray.200', 'gray.700');
 
   const handleLogout = async () => {
     await logout();
@@ -30,89 +15,77 @@ export default function Header() {
 
   const displayName = user?.displayName || user?.email?.split('@')[0] || 'ユーザー';
 
+  const getAvatarColor = (name: string) => {
+    const colors = [
+      'linear-gradient(135deg, #38b2ac, #319795)',
+      'linear-gradient(135deg, #ed64a6, #d53f8c)',
+      'linear-gradient(135deg, #a0522d, #8b4513)',
+      'linear-gradient(135deg, #9f7aea, #805ad5)',
+      'linear-gradient(135deg, #ecc94b, #d69e2e)',
+      'linear-gradient(135deg, #4299e1, #3182ce)',
+      'linear-gradient(135deg, #48bb78, #38a169)',
+      'linear-gradient(135deg, #fc8181, #f56565)',
+    ];
+    let hash = 0;
+    for (let i = 0; i < name.length; i++) {
+      hash = name.charCodeAt(i) + ((hash << 5) - hash);
+    }
+    return colors[Math.abs(hash) % colors.length];
+  };
+
   return (
-    <Box
-      position="fixed"
-      top={0}
-      left="250px"
-      right={0}
-      h="64px"
-      bg={bgColor}
-      borderBottom="1px"
-      borderColor={borderColor}
-      px={6}
-      zIndex={9}
-    >
-      <Flex h="full" align="center" justify="space-between">
-        <Box>
-          <Text fontSize="lg" fontWeight="semibold" color="gray.700">
-            ようこそ、{displayName}さん
-          </Text>
-          <Text fontSize="sm" color="gray.500">
-            今日も良い一日を
-          </Text>
-        </Box>
+    <header className={styles.header}>
+      <div className={styles.headerInner}>
+        <div className={styles.headerGreeting}>
+          <p className={styles.headerTitle}>ようこそ、{displayName}さん</p>
+          <p className={styles.headerSubtitle}>今日も良い一日を</p>
+        </div>
 
-        <HStack spacing={4}>
-          <IconButton
-            aria-label="通知"
-            icon={<FiBell />}
-            variant="ghost"
-            position="relative"
-            size="lg"
+        <div className={styles.headerActions}>
+          <button className={styles.notificationButton} aria-label="通知">
+            <FiBell />
+            <span className={styles.notificationBadge}>3</span>
+          </button>
+
+          <Menu
+            trigger={
+              <div className={styles.userMenu}>
+                <div className={styles.userInfo}>
+                  <p className={styles.userName}>{displayName}</p>
+                  <div className={styles.userStatus}>
+                    <span className={styles.statusBadge}>オンライン</span>
+                  </div>
+                </div>
+                {user?.photoURL ? (
+                  <img
+                    src={user.photoURL}
+                    alt={displayName}
+                    className={styles.avatar}
+                  />
+                ) : (
+                  <div
+                    className={styles.avatarPlaceholder}
+                    style={{ background: getAvatarColor(displayName) }}
+                  >
+                    {displayName.charAt(0)}
+                  </div>
+                )}
+              </div>
+            }
           >
-            <Badge
-              position="absolute"
-              top="8px"
-              right="8px"
-              colorScheme="red"
-              borderRadius="full"
-              w="18px"
-              h="18px"
-              fontSize="xs"
-              display="flex"
-              alignItems="center"
-              justifyContent="center"
-            >
-              3
-            </Badge>
-          </IconButton>
-
-          <Menu>
-            <MenuButton>
-              <HStack spacing={3} cursor="pointer">
-                <Box textAlign="right">
-                  <Text fontSize="sm" fontWeight="medium" color="gray.700">
-                    {displayName}
-                  </Text>
-                  <HStack spacing={1} justify="flex-end">
-                    <Badge colorScheme="green" fontSize="xs" px={2}>
-                      オンライン
-                    </Badge>
-                  </HStack>
-                </Box>
-                <Avatar
-                  size="sm"
-                  name={displayName}
-                  src={user?.photoURL || undefined}
-                />
-              </HStack>
-            </MenuButton>
-            <MenuList>
-              <MenuItem icon={<FiUser />} onClick={() => router.push('/profile')}>
-                プロフィール
-              </MenuItem>
-              <MenuItem icon={<FiSettings />} onClick={() => router.push('/settings')}>
-                設定
-              </MenuItem>
-              <MenuDivider />
-              <MenuItem icon={<FiLogOut />} color="red.500" onClick={handleLogout}>
-                ログアウト
-              </MenuItem>
-            </MenuList>
+            <MenuItem icon={<FiUser />} onClick={() => router.push('/profile')}>
+              プロフィール
+            </MenuItem>
+            <MenuItem icon={<FiSettings />} onClick={() => router.push('/settings')}>
+              設定
+            </MenuItem>
+            <MenuDivider />
+            <MenuItem icon={<FiLogOut />} color="#c53030" onClick={handleLogout}>
+              ログアウト
+            </MenuItem>
           </Menu>
-        </HStack>
-      </Flex>
-    </Box>
+        </div>
+      </div>
+    </header>
   );
 }

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,7 +1,7 @@
-import { Box } from '@chakra-ui/react';
 import { ReactNode } from 'react';
 import Sidebar from './Sidebar';
 import Header from './Header';
+import styles from '../../styles/components/layout.module.css';
 
 interface LayoutProps {
   children: ReactNode;
@@ -9,16 +9,12 @@ interface LayoutProps {
 
 export default function Layout({ children }: LayoutProps) {
   return (
-    <Box minH="100vh" bg="gray.50">
+    <div className={styles.layoutContainer}>
       <Sidebar />
       <Header />
-      <Box
-        ml="250px"
-        mt="64px"
-        p={6}
-      >
+      <div className={styles.mainContent}>
         {children}
-      </Box>
-    </Box>
+      </div>
+    </div>
   );
 }

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,4 +1,3 @@
-import { Box, VStack, HStack, Icon, Text, Link as ChakraLink } from '@chakra-ui/react';
 import { motion } from 'framer-motion';
 import NextLink from 'next/link';
 import { useRouter } from 'next/router';
@@ -12,13 +11,12 @@ import {
   FiSettings,
   FiUser,
 } from 'react-icons/fi';
-
-const MotionBox = motion(Box);
+import styles from '../../styles/components/layout.module.css';
 
 interface NavItem {
   label: string;
   href: string;
-  icon: any;
+  icon: React.ComponentType<{ className?: string }>;
 }
 
 const navItems: NavItem[] = [
@@ -36,81 +34,47 @@ export default function Sidebar() {
   const router = useRouter();
 
   return (
-    <Box
-      as="nav"
-      position="fixed"
-      left={0}
-      top={0}
-      h="100vh"
-      w="250px"
-      bg="white"
-      borderRight="1px"
-      borderColor="gray.200"
-      p={4}
-      zIndex={10}
-    >
-      <VStack align="stretch" spacing={1}>
-        <Box mb={6} px={3}>
-          <Text fontSize="2xl" fontWeight="bold" color="primary.600">
-            TaskFlow
-          </Text>
-          <Text fontSize="sm" color="gray.500">
-            プロジェクト管理
-          </Text>
-        </Box>
+    <nav className={styles.sidebar}>
+      <div className={styles.sidebarNav}>
+        <div className={styles.sidebarLogo}>
+          <p className={styles.sidebarTitle}>TaskFlow</p>
+          <p className={styles.sidebarSubtitle}>プロジェクト管理</p>
+        </div>
 
         {navItems.map((item) => {
           const isActive = router.pathname === item.href;
+          const Icon = item.icon;
 
           return (
-            <NextLink key={item.href} href={item.href} passHref legacyBehavior>
-              <ChakraLink
-                _hover={{ textDecoration: 'none' }}
-                position="relative"
+            <NextLink key={item.href} href={item.href} className={styles.navItem}>
+              <motion.div
+                whileHover={{ x: 4 }}
+                transition={{ duration: 0.2 }}
+                style={{ position: 'relative' }}
               >
-                <MotionBox
-                  position="relative"
-                  whileHover={{ x: 4 }}
-                  transition={{ duration: 0.2 }}
+                <div
+                  className={`${styles.navItemInner} ${isActive ? styles.navItemActive : ''}`}
                 >
-                  <HStack
-                    p={3}
-                    borderRadius="md"
-                    bg={isActive ? 'primary.50' : 'transparent'}
-                    color={isActive ? 'primary.600' : 'gray.700'}
-                    _hover={{
-                      bg: isActive ? 'primary.50' : 'gray.50',
+                  <Icon className={styles.navIcon} />
+                  <span>{item.label}</span>
+                </div>
+                {isActive && (
+                  <motion.div
+                    className={styles.activeIndicator}
+                    layoutId="activeTab"
+                    initial={false}
+                    transition={{
+                      type: 'spring',
+                      stiffness: 500,
+                      damping: 30,
                     }}
-                    fontWeight={isActive ? 'semibold' : 'medium'}
-                    spacing={3}
-                  >
-                    <Icon as={item.icon} boxSize={5} />
-                    <Text fontSize="sm">{item.label}</Text>
-                  </HStack>
-                  {isActive && (
-                    <MotionBox
-                      position="absolute"
-                      left={0}
-                      top={0}
-                      bottom={0}
-                      w="3px"
-                      bg="primary.500"
-                      borderRadius="full"
-                      layoutId="activeTab"
-                      initial={false}
-                      transition={{
-                        type: 'spring',
-                        stiffness: 500,
-                        damping: 30,
-                      }}
-                    />
-                  )}
-                </MotionBox>
-              </ChakraLink>
+                  />
+                )}
+              </motion.div>
             </NextLink>
           );
         })}
-      </VStack>
-    </Box>
+      </div>
+    </nav>
   );
 }

--- a/src/components/ui/Menu.module.css
+++ b/src/components/ui/Menu.module.css
@@ -39,7 +39,9 @@
 }
 
 .menuItem {
-  display: block;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
   width: 100%;
   padding: var(--spacing-2) var(--spacing-4);
   text-align: left;
@@ -53,4 +55,18 @@
 
 .menuItem:hover {
   background-color: var(--color-gray-100);
+}
+
+.menuItemIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+}
+
+.menuDivider {
+  height: 1px;
+  margin: var(--spacing-1) 0;
+  background-color: var(--color-gray-200);
 }

--- a/src/components/ui/Menu.tsx
+++ b/src/components/ui/Menu.tsx
@@ -26,11 +26,15 @@ export const Menu = ({ trigger, children }: MenuProps) => {
     };
   }, [isOpen]);
 
+  const handleItemClick = () => {
+    setIsOpen(false);
+  };
+
   return (
     <div className={styles.menu} ref={menuRef}>
       <div onClick={() => setIsOpen(!isOpen)}>{trigger}</div>
       {isOpen && (
-        <div className={styles.menuList}>
+        <div className={styles.menuList} onClick={handleItemClick}>
           {children}
         </div>
       )}
@@ -41,15 +45,19 @@ export const Menu = ({ trigger, children }: MenuProps) => {
 interface MenuItemProps {
   children: ReactNode;
   onClick?: () => void;
+  icon?: ReactNode;
+  color?: string;
 }
 
-export const MenuItem = ({ children, onClick }: MenuItemProps) => (
+export const MenuItem = ({ children, onClick, icon, color }: MenuItemProps) => (
   <button
     className={styles.menuItem}
     onClick={() => {
       onClick?.();
     }}
+    style={color ? { color } : undefined}
   >
+    {icon && <span className={styles.menuItemIcon}>{icon}</span>}
     {children}
   </button>
 );
@@ -64,3 +72,5 @@ export const MenuButton = ({ children, className }: MenuButtonProps) => (
     {children}
   </button>
 );
+
+export const MenuDivider = () => <div className={styles.menuDivider} />;

--- a/src/styles/components/layout.module.css
+++ b/src/styles/components/layout.module.css
@@ -1,0 +1,223 @@
+.layoutContainer {
+  min-height: 100vh;
+  background-color: var(--color-gray-50);
+}
+
+.mainContent {
+  margin-left: 250px;
+  margin-top: 64px;
+  padding: var(--spacing-6);
+}
+
+.sidebar {
+  position: fixed;
+  left: 0;
+  top: 0;
+  height: 100vh;
+  width: 250px;
+  background-color: white;
+  border-right: 1px solid var(--color-gray-200);
+  padding: var(--spacing-4);
+  z-index: 10;
+}
+
+.sidebarNav {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.sidebarLogo {
+  margin-bottom: var(--spacing-6);
+  padding: 0 var(--spacing-3);
+}
+
+.sidebarTitle {
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-blue-600);
+  margin: 0;
+}
+
+.sidebarSubtitle {
+  font-size: var(--font-size-sm);
+  color: var(--color-gray-500);
+  margin: 0;
+}
+
+.navItem {
+  position: relative;
+  text-decoration: none;
+}
+
+.navItemInner {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+  padding: var(--spacing-3);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-gray-700);
+  transition: background-color var(--transition-fast);
+}
+
+.navItemInner:hover {
+  background-color: var(--color-gray-50);
+}
+
+.navItemActive {
+  background-color: var(--color-blue-50);
+  color: var(--color-blue-600);
+  font-weight: var(--font-weight-semibold);
+}
+
+.navItemActive:hover {
+  background-color: var(--color-blue-50);
+}
+
+.navIcon {
+  width: 20px;
+  height: 20px;
+}
+
+.activeIndicator {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background-color: var(--color-blue-500);
+  border-radius: var(--radius-full);
+}
+
+.header {
+  position: fixed;
+  top: 0;
+  left: 250px;
+  right: 0;
+  height: 64px;
+  background-color: white;
+  border-bottom: 1px solid var(--color-gray-200);
+  padding: 0 var(--spacing-6);
+  z-index: 9;
+}
+
+.headerInner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 100%;
+}
+
+.headerGreeting {
+  display: flex;
+  flex-direction: column;
+}
+
+.headerTitle {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-gray-700);
+  margin: 0;
+}
+
+.headerSubtitle {
+  font-size: var(--font-size-sm);
+  color: var(--color-gray-500);
+  margin: 0;
+}
+
+.headerActions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-4);
+}
+
+.notificationButton {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  color: var(--color-gray-600);
+  font-size: var(--font-size-xl);
+  transition: background-color var(--transition-fast);
+}
+
+.notificationButton:hover {
+  background-color: var(--color-gray-100);
+}
+
+.notificationBadge {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  background-color: var(--color-error);
+  color: white;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  border-radius: var(--radius-full);
+}
+
+.userMenu {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+  cursor: pointer;
+}
+
+.userInfo {
+  text-align: right;
+}
+
+.userName {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-gray-700);
+  margin: 0;
+}
+
+.userStatus {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-1);
+}
+
+.statusBadge {
+  padding: var(--spacing-1) var(--spacing-2);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-green-800);
+  background-color: var(--color-green-100);
+  border-radius: var(--radius-sm);
+}
+
+.avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-full);
+  object-fit: cover;
+}
+
+.avatarPlaceholder {
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-full);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
+  color: white;
+}


### PR DESCRIPTION
## Summary
- Layout, Sidebar, HeaderコンポーネントをCSS Modulesに移行
- MenuコンポーネントにMenuDivider、icon、colorサポートを追加
- framer-motionのアニメーションを維持

## 変更内容
- `src/components/layout/Layout.tsx` - CSS Modulesに移行
- `src/components/layout/Sidebar.tsx` - CSS Modulesに移行
- `src/components/layout/Header.tsx` - CSS Modulesに移行
- `src/components/ui/Menu.tsx` - MenuDivider、icon、color追加
- `src/components/ui/Menu.module.css` - 新しいスタイル追加
- `src/styles/components/layout.module.css` - 新規作成

## Closes
- #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)