### PR TITLE
プロジェクト一覧ページをCSS Modulesに移行

### DIFF
--- a/src/pages/projects/index.tsx
+++ b/src/pages/projects/index.tsx
@@ -1,32 +1,5 @@
 import { useState } from 'react';
 import {
-  Box,
-  Heading,
-  Text,
-  VStack,
-  HStack,
-  Table,
-  Thead,
-  Tbody,
-  Tr,
-  Th,
-  Td,
-  Badge,
-  Avatar,
-  AvatarGroup,
-  Button,
-  Input,
-  InputGroup,
-  InputLeftElement,
-  Menu,
-  MenuButton,
-  MenuList,
-  MenuItem,
-  IconButton,
-  Tooltip,
-  Progress,
-} from '@chakra-ui/react';
-import {
   FiSearch,
   FiPlus,
   FiMoreVertical,
@@ -39,25 +12,26 @@ import { motion } from 'framer-motion';
 import { useRouter } from 'next/router';
 import Layout from '../../components/layout/Layout';
 import { mockProjects } from '../../lib/mockData';
-
-const MotionTr = motion(Tr);
+import { Menu, MenuItem } from '../../components/ui/Menu';
+import Tooltip from '../../components/ui/Tooltip';
+import styles from '../../styles/pages/projects.module.css';
 
 export default function ProjectsPage() {
   const router = useRouter();
   const [searchQuery, setSearchQuery] = useState('');
 
-  const getProjectStatusColor = (status: string) => {
+  const getProjectStatusBadgeClass = (status: string) => {
     switch (status) {
       case 'completed':
-        return 'green';
+        return styles.badgeGreen;
       case 'active':
-        return 'blue';
+        return styles.badgeBlue;
       case 'planning':
-        return 'gray';
+        return styles.badgeGray;
       case 'on-hold':
-        return 'orange';
+        return styles.badgeOrange;
       default:
-        return 'gray';
+        return styles.badgeGray;
     }
   };
 
@@ -74,6 +48,31 @@ export default function ProjectsPage() {
       default:
         return status;
     }
+  };
+
+  const getProgressFillClass = (progress: number) => {
+    if (progress >= 75) return styles.progressFillGreen;
+    if (progress >= 50) return styles.progressFillBlue;
+    if (progress >= 25) return styles.progressFillOrange;
+    return styles.progressFillRed;
+  };
+
+  const getAvatarColor = (name: string) => {
+    const colors = [
+      'linear-gradient(135deg, #38b2ac, #319795)',
+      'linear-gradient(135deg, #ed64a6, #d53f8c)',
+      'linear-gradient(135deg, #a0522d, #8b4513)',
+      'linear-gradient(135deg, #9f7aea, #805ad5)',
+      'linear-gradient(135deg, #ecc94b, #d69e2e)',
+      'linear-gradient(135deg, #4299e1, #3182ce)',
+      'linear-gradient(135deg, #48bb78, #38a169)',
+      'linear-gradient(135deg, #fc8181, #f56565)',
+    ];
+    let hash = 0;
+    for (let i = 0; i < name.length; i++) {
+      hash = name.charCodeAt(i) + ((hash << 5) - hash);
+    }
+    return colors[Math.abs(hash) % colors.length];
   };
 
   const formatDate = (date: Date) => {
@@ -93,204 +92,203 @@ export default function ProjectsPage() {
 
   return (
     <Layout>
-      <VStack align="stretch" spacing={6}>
-        <Box>
-          <Heading size="lg" mb={2}>
-            プロジェクト一覧
-          </Heading>
-          <Text color="gray.600">
-            すべてのプロジェクトを管理できます
-          </Text>
-        </Box>
+      <div className={styles.container}>
+        <div className={styles.header}>
+          <h1 className={styles.title}>プロジェクト一覧</h1>
+          <p className={styles.subtitle}>すべてのプロジェクトを管理できます</p>
+        </div>
 
-        <HStack justify="space-between">
-          <InputGroup maxW="400px">
-            <InputLeftElement pointerEvents="none">
-              <FiSearch color="gray" />
-            </InputLeftElement>
-            <Input
+        <div className={styles.toolbar}>
+          <div className={styles.searchContainer}>
+            <FiSearch className={styles.searchIcon} />
+            <input
+              type="text"
+              className={styles.searchInput}
               placeholder="プロジェクトを検索..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              bg="white"
             />
-          </InputGroup>
+          </div>
 
-          <Button
-            leftIcon={<FiPlus />}
-            colorScheme="primary"
+          <button
+            className={styles.addButton}
             onClick={() => {
-              // 新規作成ハンドラー
               console.log('新規プロジェクト作成');
             }}
           >
+            <FiPlus />
             新規プロジェクト
-          </Button>
-        </HStack>
+          </button>
+        </div>
 
-        <Box bg="white" borderRadius="lg" boxShadow="sm" overflow="hidden">
-          <Table variant="simple">
-            <Thead bg="gray.50">
-              <Tr>
-                <Th>プロジェクト名</Th>
-                <Th>オーナー</Th>
-                <Th>メンバー</Th>
-                <Th>ステータス</Th>
-                <Th>進捗</Th>
-                <Th>期限</Th>
-                <Th width="50px">操作</Th>
-              </Tr>
-            </Thead>
-            <Tbody>
+        <div className={styles.tableContainer}>
+          <table className={styles.table}>
+            <thead className={styles.tableHeader}>
+              <tr>
+                <th className={styles.th}>プロジェクト名</th>
+                <th className={styles.th}>オーナー</th>
+                <th className={styles.th}>メンバー</th>
+                <th className={styles.th}>ステータス</th>
+                <th className={styles.th}>進捗</th>
+                <th className={styles.th}>期限</th>
+                <th className={`${styles.th} ${styles.thActions}`}>操作</th>
+              </tr>
+            </thead>
+            <tbody>
               {filteredProjects.map((project) => (
-                <MotionTr
+                <motion.tr
                   key={project.id}
+                  className={styles.tr}
                   initial={{ opacity: 0, y: 10 }}
                   animate={{ opacity: 1, y: 0 }}
                   whileHover={{ backgroundColor: 'rgba(0, 0, 0, 0.02)' }}
                   transition={{ duration: 0.2 }}
-                  cursor="pointer"
                   onClick={() => router.push(`/projects/${project.id}`)}
                 >
-                  <Td>
-                    <VStack align="start" spacing={1}>
-                      <Text fontWeight="semibold">{project.name}</Text>
-                      <Text fontSize="sm" color="gray.600" noOfLines={1}>
-                        {project.description}
-                      </Text>
-                    </VStack>
-                  </Td>
-                  <Td>
-                    <HStack spacing={2}>
-                      <Avatar
-                        size="sm"
-                        name={project.owner.name}
-                        src={project.owner.avatar}
-                      />
-                      <Text fontSize="sm">{project.owner.name}</Text>
-                    </HStack>
-                  </Td>
-                  <Td>
-                    <Tooltip
-                      label={project.members.map((m) => m.name).join(', ')}
-                      placement="top"
-                    >
-                      <HStack spacing={2}>
-                        <AvatarGroup size="sm" max={3}>
-                          {project.members.map((member) => (
-                            <Avatar
-                              key={member.id}
-                              name={member.name}
-                              src={member.avatar}
-                            />
+                  <td className={styles.td}>
+                    <div className={styles.projectInfo}>
+                      <p className={styles.projectName}>{project.name}</p>
+                      <p className={styles.projectDescription}>{project.description}</p>
+                    </div>
+                  </td>
+                  <td className={styles.td}>
+                    <div className={styles.ownerCell}>
+                      {project.owner.avatar ? (
+                        <img
+                          src={project.owner.avatar}
+                          alt={project.owner.name}
+                          className={`${styles.avatar} ${styles.avatarSm}`}
+                        />
+                      ) : (
+                        <div
+                          className={`${styles.avatarPlaceholder} ${styles.avatarPlaceholderSm}`}
+                          style={{ background: getAvatarColor(project.owner.name) }}
+                        >
+                          {project.owner.name.charAt(0)}
+                        </div>
+                      )}
+                      <p className={styles.ownerName}>{project.owner.name}</p>
+                    </div>
+                  </td>
+                  <td className={styles.td}>
+                    <Tooltip label={project.members.map((m) => m.name).join(', ')}>
+                      <div className={styles.membersCell}>
+                        <div className={styles.avatarGroup}>
+                          {project.members.slice(0, 3).map((member) => (
+                            <div key={member.id} className={styles.avatarGroupItem}>
+                              {member.avatar ? (
+                                <img
+                                  src={member.avatar}
+                                  alt={member.name}
+                                  className={`${styles.avatar} ${styles.avatarSm}`}
+                                />
+                              ) : (
+                                <div
+                                  className={`${styles.avatarPlaceholder} ${styles.avatarPlaceholderSm}`}
+                                  style={{ background: getAvatarColor(member.name) }}
+                                >
+                                  {member.name.charAt(0)}
+                                </div>
+                              )}
+                            </div>
                           ))}
-                        </AvatarGroup>
-                        <Text fontSize="sm" color="gray.600">
-                          <FiUsers style={{ display: 'inline', marginRight: '4px' }} />
+                          {project.members.length > 3 && (
+                            <div className={styles.avatarMore}>
+                              +{project.members.length - 3}
+                            </div>
+                          )}
+                        </div>
+                        <span className={styles.memberCount}>
+                          <FiUsers />
                           {project.members.length}
-                        </Text>
-                      </HStack>
+                        </span>
+                      </div>
                     </Tooltip>
-                  </Td>
-                  <Td>
-                    <Badge colorScheme={getProjectStatusColor(project.status)}>
+                  </td>
+                  <td className={styles.td}>
+                    <span className={`${styles.badge} ${getProjectStatusBadgeClass(project.status)}`}>
                       {getProjectStatusLabel(project.status)}
-                    </Badge>
-                  </Td>
-                  <Td>
-                    <VStack align="stretch" spacing={1}>
-                      <Text fontSize="sm" fontWeight="semibold">
-                        {project.progress}%
-                      </Text>
-                      <Progress
-                        value={project.progress}
-                        size="sm"
-                        colorScheme={
-                          project.progress >= 75
-                            ? 'green'
-                            : project.progress >= 50
-                            ? 'blue'
-                            : project.progress >= 25
-                            ? 'orange'
-                            : 'red'
-                        }
-                        borderRadius="full"
-                      />
-                    </VStack>
-                  </Td>
-                  <Td>
-                    <Text fontSize="sm" color="gray.600">
-                      {formatDate(project.endDate)}
-                    </Text>
-                  </Td>
-                  <Td onClick={(e) => e.stopPropagation()}>
-                    <Menu>
-                      <MenuButton
-                        as={IconButton}
-                        icon={<FiMoreVertical />}
-                        variant="ghost"
-                        size="sm"
-                        aria-label="アクション"
-                      />
-                      <MenuList>
-                        <MenuItem
-                          icon={<FiEye />}
-                          onClick={() => router.push(`/projects/${project.id}`)}
-                        >
-                          詳細を表示
-                        </MenuItem>
-                        <MenuItem
-                          icon={<FiEdit2 />}
-                          onClick={() => {
-                            console.log('編集:', project.id);
-                          }}
-                        >
-                          編集
-                        </MenuItem>
-                        <MenuItem
-                          icon={<FiTrash2 />}
-                          color="red.500"
-                          onClick={() => {
-                            console.log('削除:', project.id);
-                          }}
-                        >
-                          削除
-                        </MenuItem>
-                      </MenuList>
+                    </span>
+                  </td>
+                  <td className={styles.td}>
+                    <div className={styles.progressCell}>
+                      <p className={styles.progressValue}>{project.progress}%</p>
+                      <div className={styles.progressBar}>
+                        <div
+                          className={`${styles.progressFill} ${getProgressFillClass(project.progress)}`}
+                          style={{ width: `${project.progress}%` }}
+                        />
+                      </div>
+                    </div>
+                  </td>
+                  <td className={styles.td}>
+                    <p className={styles.dateText}>{formatDate(project.endDate)}</p>
+                  </td>
+                  <td className={styles.td} onClick={(e) => e.stopPropagation()}>
+                    <Menu
+                      trigger={
+                        <button className={styles.actionButton} aria-label="アクション">
+                          <FiMoreVertical />
+                        </button>
+                      }
+                    >
+                      <MenuItem
+                        icon={<FiEye />}
+                        onClick={() => router.push(`/projects/${project.id}`)}
+                      >
+                        詳細を表示
+                      </MenuItem>
+                      <MenuItem
+                        icon={<FiEdit2 />}
+                        onClick={() => {
+                          console.log('編集:', project.id);
+                        }}
+                      >
+                        編集
+                      </MenuItem>
+                      <MenuItem
+                        icon={<FiTrash2 />}
+                        color="#c53030"
+                        onClick={() => {
+                          console.log('削除:', project.id);
+                        }}
+                      >
+                        削除
+                      </MenuItem>
                     </Menu>
-                  </Td>
-                </MotionTr>
+                  </td>
+                </motion.tr>
               ))}
-            </Tbody>
-          </Table>
+            </tbody>
+          </table>
 
           {filteredProjects.length === 0 && (
-            <Box py={10} textAlign="center">
-              <Text color="gray.500">
+            <div className={styles.emptyState}>
+              <p className={styles.emptyText}>
                 検索条件に一致するプロジェクトが見つかりませんでした
-              </Text>
-            </Box>
+              </p>
+            </div>
           )}
-        </Box>
+        </div>
 
-        <HStack justify="space-between" fontSize="sm" color="gray.600">
-          <Text>全 {filteredProjects.length} 件のプロジェクト</Text>
-          <HStack spacing={4}>
-            <Badge colorScheme="blue">
+        <div className={styles.footer}>
+          <p className={styles.footerText}>全 {filteredProjects.length} 件のプロジェクト</p>
+          <div className={styles.footerBadges}>
+            <span className={`${styles.badge} ${styles.badgeBlue}`}>
               進行中 {mockProjects.filter((p) => p.status === 'active').length}
-            </Badge>
-            <Badge colorScheme="green">
+            </span>
+            <span className={`${styles.badge} ${styles.badgeGreen}`}>
               完了 {mockProjects.filter((p) => p.status === 'completed').length}
-            </Badge>
-            <Badge colorScheme="gray">
+            </span>
+            <span className={`${styles.badge} ${styles.badgeGray}`}>
               計画中 {mockProjects.filter((p) => p.status === 'planning').length}
-            </Badge>
-            <Badge colorScheme="orange">
+            </span>
+            <span className={`${styles.badge} ${styles.badgeOrange}`}>
               保留 {mockProjects.filter((p) => p.status === 'on-hold').length}
-            </Badge>
-          </HStack>
-        </HStack>
-      </VStack>
+            </span>
+          </div>
+        </div>
+      </div>
     </Layout>
   );
 }

--- a/src/styles/pages/projects.module.css
+++ b/src/styles/pages/projects.module.css
@@ -1,0 +1,360 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-6);
+}
+
+.header {
+  margin-bottom: var(--spacing-2);
+}
+
+.title {
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-bold);
+  margin: 0 0 var(--spacing-2) 0;
+}
+
+.subtitle {
+  color: var(--color-gray-600);
+  margin: 0;
+}
+
+.toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.searchContainer {
+  position: relative;
+  max-width: 400px;
+  width: 100%;
+}
+
+.searchIcon {
+  position: absolute;
+  left: var(--spacing-3);
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--color-gray-400);
+  pointer-events: none;
+}
+
+.searchInput {
+  width: 100%;
+  padding: var(--spacing-2) var(--spacing-4) var(--spacing-2) var(--spacing-10);
+  font-size: var(--font-size-md);
+  border: 1px solid var(--color-gray-300);
+  border-radius: var(--radius-md);
+  background-color: white;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.searchInput:focus {
+  outline: none;
+  border-color: var(--color-blue-500);
+  box-shadow: 0 0 0 1px var(--color-blue-500);
+}
+
+.searchInput::placeholder {
+  color: var(--color-gray-400);
+}
+
+.addButton {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-2) var(--spacing-4);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
+  color: white;
+  background-color: var(--color-blue-500);
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background-color var(--transition-fast);
+}
+
+.addButton:hover {
+  background-color: var(--color-blue-600);
+}
+
+.tableContainer {
+  background-color: white;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+  overflow: hidden;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.tableHeader {
+  background-color: var(--color-gray-50);
+}
+
+.th {
+  padding: var(--spacing-3) var(--spacing-4);
+  text-align: left;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-gray-600);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.thActions {
+  width: 50px;
+}
+
+.tr {
+  border-bottom: 1px solid var(--color-gray-100);
+  cursor: pointer;
+  transition: background-color var(--transition-fast);
+}
+
+.tr:hover {
+  background-color: rgba(0, 0, 0, 0.02);
+}
+
+.tr:last-child {
+  border-bottom: none;
+}
+
+.td {
+  padding: var(--spacing-4);
+  vertical-align: middle;
+}
+
+.projectInfo {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.projectName {
+  font-weight: var(--font-weight-semibold);
+  margin: 0;
+}
+
+.projectDescription {
+  font-size: var(--font-size-sm);
+  color: var(--color-gray-600);
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 200px;
+}
+
+.ownerCell {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+}
+
+.ownerName {
+  font-size: var(--font-size-sm);
+  margin: 0;
+}
+
+.membersCell {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+}
+
+.avatarGroup {
+  display: flex;
+  flex-direction: row-reverse;
+}
+
+.avatarGroupItem {
+  margin-left: -8px;
+  border: 2px solid white;
+  border-radius: var(--radius-full);
+}
+
+.avatarGroupItem:last-child {
+  margin-left: 0;
+}
+
+.avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-full);
+  object-fit: cover;
+}
+
+.avatarSm {
+  width: 28px;
+  height: 28px;
+}
+
+.avatarPlaceholder {
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-full);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
+  color: white;
+}
+
+.avatarPlaceholderSm {
+  width: 28px;
+  height: 28px;
+  font-size: var(--font-size-xs);
+}
+
+.avatarMore {
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-full);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-gray-600);
+  background-color: var(--color-gray-200);
+  border: 2px solid white;
+  margin-left: -8px;
+}
+
+.memberCount {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: var(--font-size-sm);
+  color: var(--color-gray-600);
+}
+
+.badge {
+  display: inline-block;
+  padding: var(--spacing-1) var(--spacing-2);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  border-radius: var(--radius-sm);
+}
+
+.badgeGreen {
+  color: var(--color-green-800);
+  background-color: var(--color-green-100);
+}
+
+.badgeBlue {
+  color: var(--color-blue-800);
+  background-color: var(--color-blue-100);
+}
+
+.badgeGray {
+  color: var(--color-gray-700);
+  background-color: var(--color-gray-200);
+}
+
+.badgeOrange {
+  color: #c05621;
+  background-color: #feebc8;
+}
+
+.badgeRed {
+  color: #c53030;
+  background-color: #fed7d7;
+}
+
+.progressCell {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.progressValue {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  margin: 0;
+}
+
+.progressBar {
+  height: 6px;
+  width: 80px;
+  background-color: var(--color-gray-200);
+  border-radius: var(--radius-full);
+  overflow: hidden;
+}
+
+.progressFill {
+  height: 100%;
+  transition: width 0.3s;
+}
+
+.progressFillGreen {
+  background-color: var(--color-green-500);
+}
+
+.progressFillBlue {
+  background-color: var(--color-blue-500);
+}
+
+.progressFillOrange {
+  background-color: #dd6b20;
+}
+
+.progressFillRed {
+  background-color: #e53e3e;
+}
+
+.dateText {
+  font-size: var(--font-size-sm);
+  color: var(--color-gray-600);
+  margin: 0;
+}
+
+.actionButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  color: var(--color-gray-600);
+  transition: background-color var(--transition-fast);
+}
+
+.actionButton:hover {
+  background-color: var(--color-gray-100);
+}
+
+.emptyState {
+  padding: var(--spacing-10);
+  text-align: center;
+}
+
+.emptyText {
+  color: var(--color-gray-500);
+  margin: 0;
+}
+
+.footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: var(--font-size-sm);
+  color: var(--color-gray-600);
+}
+
+.footerText {
+  margin: 0;
+}
+
+.footerBadges {
+  display: flex;
+  gap: var(--spacing-4);
+}


### PR DESCRIPTION
## Summary
- プロジェクト一覧ページ（src/pages/projects/index.tsx）をChakra UIからCSS Modulesに移行
- projects.module.css を新規作成
- テーブル、検索、バッジ、プログレスバー、アバターグループのスタイルを実装

## Changes
- テーブルレイアウト（ヘッダー、行、セル）
- 検索ボックス（アイコン付き）
- 新規プロジェクトボタン
- ステータスバッジ（進行中、完了、計画中、保留）
- プログレスバー（進捗に応じたカラー）
- アバターグループ（重なり表示）
- アクションメニュー（カスタムMenuコンポーネント）

## Test plan
- [x] Before/After スクリーンショットで視覚的に確認
- [x] ビルドが成功することを確認

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)