### PR TITLE
feat: レイアウトコンポーネントをCSS Modulesで実装

### DIFF
--- a/src/components/ui/Box.module.css
+++ b/src/components/ui/Box.module.css
@@ -1,0 +1,3 @@
+.box {
+  box-sizing: border-box;
+}

--- a/src/components/ui/Box.tsx
+++ b/src/components/ui/Box.tsx
@@ -1,0 +1,147 @@
+import React, { forwardRef } from 'react';
+import styles from './Box.module.css';
+
+type SpacingValue = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 8 | 10 | 12 | 16 | 20 | 24;
+
+export interface BoxProps extends React.HTMLAttributes<HTMLDivElement> {
+  as?: React.ElementType;
+  p?: SpacingValue;
+  px?: SpacingValue;
+  py?: SpacingValue;
+  pt?: SpacingValue;
+  pb?: SpacingValue;
+  pl?: SpacingValue;
+  pr?: SpacingValue;
+  m?: SpacingValue;
+  mx?: SpacingValue;
+  my?: SpacingValue;
+  mt?: SpacingValue;
+  mb?: SpacingValue;
+  ml?: SpacingValue;
+  mr?: SpacingValue;
+  bg?: string;
+  color?: string;
+  borderRadius?: 'none' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | 'full';
+  shadow?: 'sm' | 'md' | 'lg' | 'xl' | '2xl';
+  display?: 'block' | 'flex' | 'inline' | 'inline-block' | 'inline-flex' | 'none';
+  position?: 'static' | 'relative' | 'absolute' | 'fixed' | 'sticky';
+  w?: string;
+  h?: string;
+  minH?: string;
+  maxW?: string;
+  textAlign?: 'left' | 'center' | 'right';
+  overflow?: 'visible' | 'hidden' | 'scroll' | 'auto';
+  zIndex?: number;
+}
+
+const spacingMap: Record<SpacingValue, string> = {
+  0: '0',
+  1: 'var(--spacing-1)',
+  2: 'var(--spacing-2)',
+  3: 'var(--spacing-3)',
+  4: 'var(--spacing-4)',
+  5: 'var(--spacing-5)',
+  6: 'var(--spacing-6)',
+  8: 'var(--spacing-8)',
+  10: 'var(--spacing-10)',
+  12: 'var(--spacing-12)',
+  16: 'var(--spacing-16)',
+  20: 'var(--spacing-20)',
+  24: 'var(--spacing-24)',
+};
+
+const radiusMap: Record<string, string> = {
+  none: 'var(--radius-none)',
+  sm: 'var(--radius-sm)',
+  md: 'var(--radius-md)',
+  lg: 'var(--radius-lg)',
+  xl: 'var(--radius-xl)',
+  '2xl': 'var(--radius-2xl)',
+  full: 'var(--radius-full)',
+};
+
+const shadowMap: Record<string, string> = {
+  sm: 'var(--shadow-sm)',
+  md: 'var(--shadow-md)',
+  lg: 'var(--shadow-lg)',
+  xl: 'var(--shadow-xl)',
+  '2xl': 'var(--shadow-2xl)',
+};
+
+export const Box = forwardRef<HTMLDivElement, BoxProps>(({
+  as: Component = 'div',
+  p,
+  px,
+  py,
+  pt,
+  pb,
+  pl,
+  pr,
+  m,
+  mx,
+  my,
+  mt,
+  mb,
+  ml,
+  mr,
+  bg,
+  color,
+  borderRadius,
+  shadow,
+  display,
+  position,
+  w,
+  h,
+  minH,
+  maxW,
+  textAlign,
+  overflow,
+  zIndex,
+  className,
+  style,
+  children,
+  ...props
+}, ref) => {
+  const customStyle: React.CSSProperties = {
+    ...(p !== undefined && { padding: spacingMap[p] }),
+    ...(px !== undefined && { paddingLeft: spacingMap[px], paddingRight: spacingMap[px] }),
+    ...(py !== undefined && { paddingTop: spacingMap[py], paddingBottom: spacingMap[py] }),
+    ...(pt !== undefined && { paddingTop: spacingMap[pt] }),
+    ...(pb !== undefined && { paddingBottom: spacingMap[pb] }),
+    ...(pl !== undefined && { paddingLeft: spacingMap[pl] }),
+    ...(pr !== undefined && { paddingRight: spacingMap[pr] }),
+    ...(m !== undefined && { margin: spacingMap[m] }),
+    ...(mx !== undefined && { marginLeft: spacingMap[mx], marginRight: spacingMap[mx] }),
+    ...(my !== undefined && { marginTop: spacingMap[my], marginBottom: spacingMap[my] }),
+    ...(mt !== undefined && { marginTop: spacingMap[mt] }),
+    ...(mb !== undefined && { marginBottom: spacingMap[mb] }),
+    ...(ml !== undefined && { marginLeft: spacingMap[ml] }),
+    ...(mr !== undefined && { marginRight: spacingMap[mr] }),
+    ...(bg && { backgroundColor: bg }),
+    ...(color && { color }),
+    ...(borderRadius && { borderRadius: radiusMap[borderRadius] }),
+    ...(shadow && { boxShadow: shadowMap[shadow] }),
+    ...(display && { display }),
+    ...(position && { position }),
+    ...(w && { width: w }),
+    ...(h && { height: h }),
+    ...(minH && { minHeight: minH }),
+    ...(maxW && { maxWidth: maxW }),
+    ...(textAlign && { textAlign }),
+    ...(overflow && { overflow }),
+    ...(zIndex !== undefined && { zIndex }),
+    ...style,
+  };
+
+  const classNames = [styles.box, className].filter(Boolean).join(' ');
+
+  return (
+    <Component ref={ref} className={classNames} style={customStyle} {...props}>
+      {children}
+    </Component>
+  );
+});
+
+Box.displayName = 'Box';
+
+export default Box;

--- a/src/components/ui/Center.module.css
+++ b/src/components/ui/Center.module.css
@@ -1,0 +1,5 @@
+.center {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/src/components/ui/Center.tsx
+++ b/src/components/ui/Center.tsx
@@ -1,0 +1,26 @@
+import React, { forwardRef } from 'react';
+import { Box, BoxProps } from './Box';
+import styles from './Center.module.css';
+
+export interface CenterProps extends BoxProps {}
+
+export const Center = forwardRef<HTMLDivElement, CenterProps>(({
+  className,
+  style,
+  ...props
+}, ref) => {
+  const centerStyle: React.CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    ...style,
+  };
+
+  const classNames = [styles.center, className].filter(Boolean).join(' ');
+
+  return <Box ref={ref} className={classNames} style={centerStyle} {...props} />;
+});
+
+Center.displayName = 'Center';
+
+export default Center;

--- a/src/components/ui/Flex.module.css
+++ b/src/components/ui/Flex.module.css
@@ -1,0 +1,3 @@
+.flex {
+  display: flex;
+}

--- a/src/components/ui/Flex.tsx
+++ b/src/components/ui/Flex.tsx
@@ -1,0 +1,53 @@
+import React, { forwardRef } from 'react';
+import { Box, BoxProps } from './Box';
+import styles from './Flex.module.css';
+
+export interface FlexProps extends BoxProps {
+  direction?: 'row' | 'column' | 'row-reverse' | 'column-reverse';
+  justify?: 'flex-start' | 'flex-end' | 'center' | 'space-between' | 'space-around' | 'space-evenly';
+  align?: 'flex-start' | 'flex-end' | 'center' | 'baseline' | 'stretch';
+  wrap?: 'nowrap' | 'wrap' | 'wrap-reverse';
+  gap?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 8 | 10 | 12;
+}
+
+const gapMap: Record<number, string> = {
+  0: '0',
+  1: 'var(--spacing-1)',
+  2: 'var(--spacing-2)',
+  3: 'var(--spacing-3)',
+  4: 'var(--spacing-4)',
+  5: 'var(--spacing-5)',
+  6: 'var(--spacing-6)',
+  8: 'var(--spacing-8)',
+  10: 'var(--spacing-10)',
+  12: 'var(--spacing-12)',
+};
+
+export const Flex = forwardRef<HTMLDivElement, FlexProps>(({
+  direction,
+  justify,
+  align,
+  wrap,
+  gap,
+  className,
+  style,
+  ...props
+}, ref) => {
+  const flexStyle: React.CSSProperties = {
+    display: 'flex',
+    ...(direction && { flexDirection: direction }),
+    ...(justify && { justifyContent: justify }),
+    ...(align && { alignItems: align }),
+    ...(wrap && { flexWrap: wrap }),
+    ...(gap !== undefined && { gap: gapMap[gap] }),
+    ...style,
+  };
+
+  const classNames = [styles.flex, className].filter(Boolean).join(' ');
+
+  return <Box ref={ref} className={classNames} style={flexStyle} {...props} />;
+});
+
+Flex.displayName = 'Flex';
+
+export default Flex;

--- a/src/components/ui/HStack.module.css
+++ b/src/components/ui/HStack.module.css
@@ -1,0 +1,4 @@
+.hstack {
+  display: flex;
+  flex-direction: row;
+}

--- a/src/components/ui/HStack.tsx
+++ b/src/components/ui/HStack.tsx
@@ -1,0 +1,26 @@
+import React, { forwardRef } from 'react';
+import { Flex, FlexProps } from './Flex';
+
+export interface HStackProps extends Omit<FlexProps, 'direction'> {
+  spacing?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 8 | 10 | 12;
+}
+
+export const HStack = forwardRef<HTMLDivElement, HStackProps>(({
+  spacing = 4,
+  align = 'center',
+  ...props
+}, ref) => {
+  return (
+    <Flex
+      ref={ref}
+      direction="row"
+      align={align}
+      gap={spacing}
+      {...props}
+    />
+  );
+});
+
+HStack.displayName = 'HStack';
+
+export default HStack;

--- a/src/components/ui/Heading.module.css
+++ b/src/components/ui/Heading.module.css
@@ -1,0 +1,3 @@
+.heading {
+  margin: 0;
+}

--- a/src/components/ui/Heading.tsx
+++ b/src/components/ui/Heading.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import styles from './Heading.module.css';
+
+type HeadingSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl';
+type HeadingLevel = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+
+export interface HeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {
+  as?: HeadingLevel;
+  size?: HeadingSize;
+  color?: string;
+  textAlign?: 'left' | 'center' | 'right';
+  mb?: number;
+}
+
+const sizeToElement: Record<HeadingSize, HeadingLevel> = {
+  '4xl': 'h1',
+  '3xl': 'h1',
+  '2xl': 'h2',
+  xl: 'h2',
+  lg: 'h3',
+  md: 'h4',
+  sm: 'h5',
+  xs: 'h6',
+};
+
+const sizeToFontSize: Record<HeadingSize, string> = {
+  '4xl': 'var(--font-size-4xl)',
+  '3xl': 'var(--font-size-3xl)',
+  '2xl': 'var(--font-size-2xl)',
+  xl: 'var(--font-size-xl)',
+  lg: 'var(--font-size-lg)',
+  md: 'var(--font-size-md)',
+  sm: 'var(--font-size-sm)',
+  xs: 'var(--font-size-xs)',
+};
+
+const spacingMap: Record<number, string> = {
+  0: '0',
+  1: 'var(--spacing-1)',
+  2: 'var(--spacing-2)',
+  3: 'var(--spacing-3)',
+  4: 'var(--spacing-4)',
+  5: 'var(--spacing-5)',
+  6: 'var(--spacing-6)',
+  8: 'var(--spacing-8)',
+};
+
+export function Heading({
+  as,
+  size = 'xl',
+  color,
+  textAlign,
+  mb,
+  className,
+  style,
+  children,
+  ...props
+}: HeadingProps) {
+  const Component = as ?? sizeToElement[size];
+
+  const headingStyle: React.CSSProperties = {
+    fontSize: sizeToFontSize[size],
+    fontWeight: 'var(--font-weight-bold)',
+    fontFamily: 'var(--font-family-heading)',
+    lineHeight: 'var(--line-height-tight)',
+    ...(color && { color }),
+    ...(textAlign && { textAlign }),
+    ...(mb !== undefined && { marginBottom: spacingMap[mb] }),
+    ...style,
+  };
+
+  const classNames = [styles.heading, className].filter(Boolean).join(' ');
+
+  return (
+    <Component className={classNames} style={headingStyle} {...props}>
+      {children}
+    </Component>
+  );
+}
+
+export default Heading;

--- a/src/components/ui/SimpleGrid.module.css
+++ b/src/components/ui/SimpleGrid.module.css
@@ -1,0 +1,3 @@
+.simpleGrid {
+  display: grid;
+}

--- a/src/components/ui/SimpleGrid.tsx
+++ b/src/components/ui/SimpleGrid.tsx
@@ -1,0 +1,56 @@
+import React, { forwardRef } from 'react';
+import { Box, BoxProps } from './Box';
+import styles from './SimpleGrid.module.css';
+
+export interface SimpleGridProps extends BoxProps {
+  columns?: number | { base?: number; sm?: number; md?: number; lg?: number; xl?: number };
+  spacing?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 8 | 10 | 12;
+  spacingX?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 8 | 10 | 12;
+  spacingY?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 8 | 10 | 12;
+  minChildWidth?: string;
+}
+
+const spacingMap: Record<number, string> = {
+  0: '0',
+  1: 'var(--spacing-1)',
+  2: 'var(--spacing-2)',
+  3: 'var(--spacing-3)',
+  4: 'var(--spacing-4)',
+  5: 'var(--spacing-5)',
+  6: 'var(--spacing-6)',
+  8: 'var(--spacing-8)',
+  10: 'var(--spacing-10)',
+  12: 'var(--spacing-12)',
+};
+
+export const SimpleGrid = forwardRef<HTMLDivElement, SimpleGridProps>(({
+  columns = 1,
+  spacing = 4,
+  spacingX,
+  spacingY,
+  minChildWidth,
+  className,
+  style,
+  ...props
+}, ref) => {
+  const columnCount = typeof columns === 'number' ? columns : columns.base ?? 1;
+
+  const gridStyle: React.CSSProperties = {
+    display: 'grid',
+    gridTemplateColumns: minChildWidth
+      ? `repeat(auto-fit, minmax(${minChildWidth}, 1fr))`
+      : `repeat(${columnCount}, 1fr)`,
+    gap: spacingMap[spacing],
+    ...(spacingX !== undefined && { columnGap: spacingMap[spacingX] }),
+    ...(spacingY !== undefined && { rowGap: spacingMap[spacingY] }),
+    ...style,
+  };
+
+  const classNames = [styles.simpleGrid, className].filter(Boolean).join(' ');
+
+  return <Box ref={ref} className={classNames} style={gridStyle} {...props} />;
+});
+
+SimpleGrid.displayName = 'SimpleGrid';
+
+export default SimpleGrid;

--- a/src/components/ui/Stack.module.css
+++ b/src/components/ui/Stack.module.css
@@ -1,0 +1,3 @@
+.stack {
+  display: flex;
+}

--- a/src/components/ui/Stack.tsx
+++ b/src/components/ui/Stack.tsx
@@ -1,0 +1,25 @@
+import React, { forwardRef } from 'react';
+import { Flex, FlexProps } from './Flex';
+
+export interface StackProps extends FlexProps {
+  spacing?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 8 | 10 | 12;
+}
+
+export const Stack = forwardRef<HTMLDivElement, StackProps>(({
+  spacing = 4,
+  direction = 'column',
+  ...props
+}, ref) => {
+  return (
+    <Flex
+      ref={ref}
+      direction={direction}
+      gap={spacing}
+      {...props}
+    />
+  );
+});
+
+Stack.displayName = 'Stack';
+
+export default Stack;

--- a/src/components/ui/Text.module.css
+++ b/src/components/ui/Text.module.css
@@ -1,0 +1,3 @@
+.text {
+  margin: 0;
+}

--- a/src/components/ui/Text.tsx
+++ b/src/components/ui/Text.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import styles from './Text.module.css';
+
+type FontSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl';
+type FontWeight = 'normal' | 'medium' | 'semibold' | 'bold';
+
+export interface TextProps extends React.HTMLAttributes<HTMLElement> {
+  as?: 'p' | 'span' | 'div' | 'label';
+  fontSize?: FontSize;
+  fontWeight?: FontWeight;
+  color?: string;
+  noOfLines?: number;
+  textAlign?: 'left' | 'center' | 'right';
+  maxW?: string;
+}
+
+const fontSizeMap: Record<FontSize, string> = {
+  xs: 'var(--font-size-xs)',
+  sm: 'var(--font-size-sm)',
+  md: 'var(--font-size-md)',
+  lg: 'var(--font-size-lg)',
+  xl: 'var(--font-size-xl)',
+  '2xl': 'var(--font-size-2xl)',
+  '3xl': 'var(--font-size-3xl)',
+  '4xl': 'var(--font-size-4xl)',
+};
+
+const fontWeightMap: Record<FontWeight, string> = {
+  normal: 'var(--font-weight-normal)',
+  medium: 'var(--font-weight-medium)',
+  semibold: 'var(--font-weight-semibold)',
+  bold: 'var(--font-weight-bold)',
+};
+
+export function Text({
+  as: Component = 'p',
+  fontSize,
+  fontWeight,
+  color,
+  noOfLines,
+  textAlign,
+  maxW,
+  className,
+  style,
+  children,
+  ...props
+}: TextProps) {
+  const textStyle: React.CSSProperties = {
+    ...(fontSize && { fontSize: fontSizeMap[fontSize] }),
+    ...(fontWeight && { fontWeight: fontWeightMap[fontWeight] }),
+    ...(color && { color }),
+    ...(textAlign && { textAlign }),
+    ...(maxW && { maxWidth: maxW }),
+    ...(noOfLines && {
+      display: '-webkit-box',
+      WebkitLineClamp: noOfLines,
+      WebkitBoxOrient: 'vertical' as const,
+      overflow: 'hidden',
+    }),
+    ...style,
+  };
+
+  const classNames = [styles.text, className].filter(Boolean).join(' ');
+
+  return (
+    <Component className={classNames} style={textStyle} {...props}>
+      {children}
+    </Component>
+  );
+}
+
+export default Text;

--- a/src/components/ui/VStack.module.css
+++ b/src/components/ui/VStack.module.css
@@ -1,0 +1,4 @@
+.vstack {
+  display: flex;
+  flex-direction: column;
+}

--- a/src/components/ui/VStack.tsx
+++ b/src/components/ui/VStack.tsx
@@ -1,0 +1,26 @@
+import React, { forwardRef } from 'react';
+import { Flex, FlexProps } from './Flex';
+
+export interface VStackProps extends Omit<FlexProps, 'direction'> {
+  spacing?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 8 | 10 | 12;
+}
+
+export const VStack = forwardRef<HTMLDivElement, VStackProps>(({
+  spacing = 4,
+  align = 'center',
+  ...props
+}, ref) => {
+  return (
+    <Flex
+      ref={ref}
+      direction="column"
+      align={align}
+      gap={spacing}
+      {...props}
+    />
+  );
+});
+
+VStack.displayName = 'VStack';
+
+export default VStack;

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,3 +1,13 @@
+export { Box } from './Box';
+export { Flex } from './Flex';
+export { Stack } from './Stack';
+export { VStack } from './VStack';
+export { HStack } from './HStack';
+export { Center } from './Center';
+export { SimpleGrid } from './SimpleGrid';
+export { Text } from './Text';
+export { Heading } from './Heading';
+
 export { default as Button } from './Button';
 export { default as Card } from './Card';
 export { default as ProgressBar } from './ProgressBar';
@@ -6,6 +16,15 @@ export { default as StatusBadge } from './StatusBadge';
 export { default as PriorityBadge } from './PriorityBadge';
 export { default as RoleBadge } from './RoleBadge';
 
+export type { BoxProps } from './Box';
+export type { FlexProps } from './Flex';
+export type { StackProps } from './Stack';
+export type { VStackProps } from './VStack';
+export type { HStackProps } from './HStack';
+export type { CenterProps } from './Center';
+export type { SimpleGridProps } from './SimpleGrid';
+export type { TextProps } from './Text';
+export type { HeadingProps } from './Heading';
 export type { ButtonVariant, ButtonSize } from './Button';
 export type { TaskStatus, ProjectStatus, UserStatus } from './StatusBadge';
 export type { Priority } from './PriorityBadge';


### PR DESCRIPTION
## Summary
- Box, Flex, Stack, VStack, HStack, Center, SimpleGrid, Text, Headingコンポーネントを追加
- CSS変数を使用したスタイリング

Closes #113

## Test plan
- [x] `npm run build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)