### PR TITLE
feat: 表示系コンポーネントをCSS Modulesで実装 (#115)

### DIFF
--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -3,4 +3,4 @@ export { default as ActionMenu } from './ActionMenu';
 export { default as UserAvatar } from './UserAvatar';
 export { default as FilterBar } from './FilterBar';
 export { default as Tooltip } from './Tooltip';
-export { default as Alert } from './Alert';
+export { default as AnimatedAlert } from './Alert';

--- a/src/components/ui/Alert.module.css
+++ b/src/components/ui/Alert.module.css
@@ -1,0 +1,52 @@
+.alert {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-3);
+  padding: var(--spacing-3) var(--spacing-4);
+  border-radius: var(--radius-md);
+}
+
+/* Status variants */
+.info {
+  background-color: var(--color-blue-50);
+  color: var(--color-blue-700);
+}
+
+.warning {
+  background-color: var(--color-yellow-50);
+  color: var(--color-yellow-700);
+}
+
+.success {
+  background-color: var(--color-green-50);
+  color: var(--color-green-700);
+}
+
+.error {
+  background-color: var(--color-red-50);
+  color: var(--color-red-700);
+}
+
+/* Alert icon */
+.alertIcon {
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.alertIcon svg {
+  width: 100%;
+  height: 100%;
+}
+
+/* Alert title */
+.alertTitle {
+  font-weight: var(--font-weight-semibold);
+  font-size: var(--font-size-md);
+}
+
+/* Alert description */
+.alertDescription {
+  font-size: var(--font-size-sm);
+  opacity: 0.9;
+}

--- a/src/components/ui/Alert.tsx
+++ b/src/components/ui/Alert.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import styles from './Alert.module.css';
+
+export type AlertStatus = 'info' | 'warning' | 'success' | 'error';
+
+export interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
+  status?: AlertStatus;
+}
+
+export function Alert({
+  status = 'info',
+  className,
+  children,
+  ...props
+}: AlertProps) {
+  const classNames = [styles.alert, styles[status], className]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div className={classNames} role="alert" {...props}>
+      {children}
+    </div>
+  );
+}
+
+export interface AlertIconProps extends React.HTMLAttributes<HTMLSpanElement> {
+  status?: AlertStatus;
+}
+
+const icons: Record<AlertStatus, React.ReactNode> = {
+  info: (
+    <svg viewBox="0 0 24 24" fill="currentColor">
+      <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z" />
+    </svg>
+  ),
+  warning: (
+    <svg viewBox="0 0 24 24" fill="currentColor">
+      <path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z" />
+    </svg>
+  ),
+  success: (
+    <svg viewBox="0 0 24 24" fill="currentColor">
+      <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z" />
+    </svg>
+  ),
+  error: (
+    <svg viewBox="0 0 24 24" fill="currentColor">
+      <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z" />
+    </svg>
+  ),
+};
+
+export function AlertIcon({ status = 'info', className, ...props }: AlertIconProps) {
+  const classNames = [styles.alertIcon, className].filter(Boolean).join(' ');
+
+  return (
+    <span className={classNames} {...props}>
+      {icons[status]}
+    </span>
+  );
+}
+
+export interface AlertTitleProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function AlertTitle({ className, children, ...props }: AlertTitleProps) {
+  const classNames = [styles.alertTitle, className].filter(Boolean).join(' ');
+  return (
+    <div className={classNames} {...props}>
+      {children}
+    </div>
+  );
+}
+
+export interface AlertDescriptionProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function AlertDescription({ className, children, ...props }: AlertDescriptionProps) {
+  const classNames = [styles.alertDescription, className].filter(Boolean).join(' ');
+  return (
+    <div className={classNames} {...props}>
+      {children}
+    </div>
+  );
+}
+
+export default Alert;

--- a/src/components/ui/Avatar.module.css
+++ b/src/components/ui/Avatar.module.css
@@ -1,0 +1,85 @@
+.avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  color: white;
+  font-weight: var(--font-weight-medium);
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.initials {
+  text-transform: uppercase;
+}
+
+.icon {
+  width: 60%;
+  height: 60%;
+  opacity: 0.8;
+}
+
+/* Sizes */
+.xs {
+  width: 24px;
+  height: 24px;
+  font-size: 10px;
+}
+
+.sm {
+  width: 32px;
+  height: 32px;
+  font-size: var(--font-size-xs);
+}
+
+.md {
+  width: 40px;
+  height: 40px;
+  font-size: var(--font-size-sm);
+}
+
+.lg {
+  width: 48px;
+  height: 48px;
+  font-size: var(--font-size-md);
+}
+
+.xl {
+  width: 64px;
+  height: 64px;
+  font-size: var(--font-size-lg);
+}
+
+.\32xl {
+  width: 96px;
+  height: 96px;
+  font-size: var(--font-size-2xl);
+}
+
+/* Avatar Group */
+.avatarGroup {
+  display: flex;
+  flex-direction: row-reverse;
+  justify-content: flex-end;
+}
+
+.avatarGroup > .avatar {
+  border: 2px solid white;
+  margin-left: -8px;
+}
+
+.avatarGroup > .avatar:last-child {
+  margin-left: 0;
+}
+
+.excess {
+  background-color: var(--color-gray-300);
+  color: var(--color-gray-700);
+  font-size: var(--font-size-xs);
+}

--- a/src/components/ui/Avatar.tsx
+++ b/src/components/ui/Avatar.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import styles from './Avatar.module.css';
+
+export type AvatarSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl';
+
+export interface AvatarProps extends React.HTMLAttributes<HTMLDivElement> {
+  size?: AvatarSize;
+  src?: string;
+  name?: string;
+  bg?: string;
+}
+
+function getInitials(name: string): string {
+  const parts = name.split(' ').filter(Boolean);
+  if (parts.length === 0) return '';
+  if (parts.length === 1) return parts[0].charAt(0).toUpperCase();
+  return (parts[0].charAt(0) + parts[parts.length - 1].charAt(0)).toUpperCase();
+}
+
+function stringToColor(str: string): string {
+  const colors = [
+    'var(--color-primary-500)',
+    'var(--color-green-500)',
+    'var(--color-blue-500)',
+    'var(--color-purple-500)',
+    'var(--color-red-500)',
+    'var(--color-yellow-500)',
+    'var(--color-accent-500)',
+  ];
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = str.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  return colors[Math.abs(hash) % colors.length];
+}
+
+export function Avatar({
+  size = 'md',
+  src,
+  name,
+  bg,
+  className,
+  style,
+  ...props
+}: AvatarProps) {
+  const classNames = [styles.avatar, styles[size], className]
+    .filter(Boolean)
+    .join(' ');
+
+  const backgroundColor = bg || (name ? stringToColor(name) : 'var(--color-gray-400)');
+
+  return (
+    <div
+      className={classNames}
+      style={{ backgroundColor, ...style }}
+      {...props}
+    >
+      {src ? (
+        <img src={src} alt={name || 'Avatar'} className={styles.image} />
+      ) : name ? (
+        <span className={styles.initials}>{getInitials(name)}</span>
+      ) : (
+        <svg className={styles.icon} viewBox="0 0 24 24" fill="currentColor">
+          <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z" />
+        </svg>
+      )}
+    </div>
+  );
+}
+
+export interface AvatarGroupProps extends React.HTMLAttributes<HTMLDivElement> {
+  max?: number;
+  size?: AvatarSize;
+}
+
+export function AvatarGroup({
+  max = 3,
+  size = 'md',
+  className,
+  children,
+  ...props
+}: AvatarGroupProps) {
+  const classNames = [styles.avatarGroup, className].filter(Boolean).join(' ');
+
+  const childArray = React.Children.toArray(children);
+  const visibleChildren = childArray.slice(0, max);
+  const excess = childArray.length - max;
+
+  return (
+    <div className={classNames} {...props}>
+      {visibleChildren.map((child, index) =>
+        React.isValidElement(child)
+          ? React.cloneElement(child, { size, key: index } as AvatarProps)
+          : child
+      )}
+      {excess > 0 && (
+        <div
+          className={`${styles.avatar} ${styles[size]} ${styles.excess}`}
+        >
+          +{excess}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default Avatar;

--- a/src/components/ui/Badge.module.css
+++ b/src/components/ui/Badge.module.css
@@ -1,0 +1,117 @@
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--spacing-1) var(--spacing-2);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  line-height: 1;
+  border-radius: var(--radius-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+}
+
+/* Solid variant */
+.solid.gray {
+  background-color: var(--color-gray-500);
+  color: white;
+}
+
+.solid.primary {
+  background-color: var(--color-primary-500);
+  color: white;
+}
+
+.solid.green {
+  background-color: var(--color-green-500);
+  color: white;
+}
+
+.solid.red {
+  background-color: var(--color-red-500);
+  color: white;
+}
+
+.solid.yellow {
+  background-color: var(--color-yellow-500);
+  color: var(--color-gray-800);
+}
+
+.solid.blue {
+  background-color: var(--color-blue-500);
+  color: white;
+}
+
+.solid.purple {
+  background-color: var(--color-purple-500);
+  color: white;
+}
+
+/* Subtle variant */
+.subtle.gray {
+  background-color: var(--color-gray-100);
+  color: var(--color-gray-700);
+}
+
+.subtle.primary {
+  background-color: var(--color-primary-100);
+  color: var(--color-primary-700);
+}
+
+.subtle.green {
+  background-color: var(--color-green-100);
+  color: var(--color-green-700);
+}
+
+.subtle.red {
+  background-color: var(--color-red-100);
+  color: var(--color-red-700);
+}
+
+.subtle.yellow {
+  background-color: var(--color-yellow-100);
+  color: var(--color-yellow-700);
+}
+
+.subtle.blue {
+  background-color: var(--color-blue-100);
+  color: var(--color-blue-700);
+}
+
+.subtle.purple {
+  background-color: var(--color-purple-100);
+  color: var(--color-purple-700);
+}
+
+/* Outline variant */
+.outline {
+  background-color: transparent;
+  border: 1px solid currentColor;
+}
+
+.outline.gray {
+  color: var(--color-gray-500);
+}
+
+.outline.primary {
+  color: var(--color-primary-500);
+}
+
+.outline.green {
+  color: var(--color-green-500);
+}
+
+.outline.red {
+  color: var(--color-red-500);
+}
+
+.outline.yellow {
+  color: var(--color-yellow-600);
+}
+
+.outline.blue {
+  color: var(--color-blue-500);
+}
+
+.outline.purple {
+  color: var(--color-purple-500);
+}

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import styles from './Badge.module.css';
+
+export type BadgeVariant = 'solid' | 'subtle' | 'outline';
+export type BadgeColorScheme = 'gray' | 'primary' | 'green' | 'red' | 'yellow' | 'blue' | 'purple';
+
+export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  variant?: BadgeVariant;
+  colorScheme?: BadgeColorScheme;
+}
+
+export function Badge({
+  variant = 'subtle',
+  colorScheme = 'gray',
+  className,
+  children,
+  ...props
+}: BadgeProps) {
+  const classNames = [
+    styles.badge,
+    styles[variant],
+    styles[colorScheme],
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <span className={classNames} {...props}>
+      {children}
+    </span>
+  );
+}
+
+export default Badge;

--- a/src/components/ui/Card.module.css
+++ b/src/components/ui/Card.module.css
@@ -1,0 +1,52 @@
+.card {
+  display: flex;
+  flex-direction: column;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+/* Variants */
+.elevated {
+  background-color: white;
+  box-shadow: var(--shadow-md);
+}
+
+.outline {
+  background-color: white;
+  border: 1px solid var(--color-gray-200);
+}
+
+.filled {
+  background-color: var(--color-gray-100);
+}
+
+/* Hoverable */
+.hoverable {
+  transition: all var(--transition-fast);
+  cursor: pointer;
+}
+
+.hoverable:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-lg);
+}
+
+.hoverable.outline:hover {
+  border-color: var(--color-primary-300);
+}
+
+/* Card sections */
+.cardHeader {
+  padding: var(--spacing-4);
+  border-bottom: 1px solid var(--color-gray-100);
+}
+
+.cardBody {
+  padding: var(--spacing-4);
+  flex: 1;
+}
+
+.cardFooter {
+  padding: var(--spacing-4);
+  border-top: 1px solid var(--color-gray-100);
+}

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,48 +1,67 @@
-import {
-  Box,
-  BoxProps,
-  useColorModeValue,
-} from '@chakra-ui/react';
-import { ReactNode } from 'react';
+import React from 'react';
+import styles from './Card.module.css';
 
-interface CardProps extends BoxProps {
-  children: ReactNode;
+export type CardVariant = 'elevated' | 'outline' | 'filled';
+
+export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
+  variant?: CardVariant;
   isHoverable?: boolean;
 }
 
-export default function Card({
-  children,
+export function Card({
+  variant = 'elevated',
   isHoverable = false,
+  className,
+  children,
   ...props
 }: CardProps) {
-  const bgColor = useColorModeValue('white', 'gray.800');
-  const borderColor = useColorModeValue('gray.200', 'gray.700');
-
-  const hoverStyles = isHoverable
-    ? {
-        _hover: {
-          borderColor: 'primary.300',
-          bg: 'gray.50',
-          transform: 'translateY(-2px)',
-          boxShadow: 'md',
-        },
-        transition: 'all 0.2s',
-        cursor: 'pointer',
-      }
-    : {};
+  const classNames = [
+    styles.card,
+    styles[variant],
+    isHoverable ? styles.hoverable : '',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
 
   return (
-    <Box
-      p={4}
-      borderRadius="lg"
-      border="1px"
-      borderColor={borderColor}
-      bg={bgColor}
-      boxShadow="sm"
-      {...hoverStyles}
-      {...props}
-    >
+    <div className={classNames} {...props}>
       {children}
-    </Box>
+    </div>
   );
 }
+
+export interface CardHeaderProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function CardHeader({ className, children, ...props }: CardHeaderProps) {
+  const classNames = [styles.cardHeader, className].filter(Boolean).join(' ');
+  return (
+    <div className={classNames} {...props}>
+      {children}
+    </div>
+  );
+}
+
+export interface CardBodyProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function CardBody({ className, children, ...props }: CardBodyProps) {
+  const classNames = [styles.cardBody, className].filter(Boolean).join(' ');
+  return (
+    <div className={classNames} {...props}>
+      {children}
+    </div>
+  );
+}
+
+export interface CardFooterProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function CardFooter({ className, children, ...props }: CardFooterProps) {
+  const classNames = [styles.cardFooter, className].filter(Boolean).join(' ');
+  return (
+    <div className={classNames} {...props}>
+      {children}
+    </div>
+  );
+}
+
+export default Card;

--- a/src/components/ui/Divider.module.css
+++ b/src/components/ui/Divider.module.css
@@ -1,0 +1,16 @@
+.divider {
+  border: none;
+  background-color: var(--color-gray-200);
+  margin: 0;
+}
+
+.horizontal {
+  width: 100%;
+  height: 1px;
+}
+
+.vertical {
+  width: 1px;
+  height: auto;
+  align-self: stretch;
+}

--- a/src/components/ui/Divider.tsx
+++ b/src/components/ui/Divider.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import styles from './Divider.module.css';
+
+export type DividerOrientation = 'horizontal' | 'vertical';
+
+export interface DividerProps extends React.HTMLAttributes<HTMLHRElement> {
+  orientation?: DividerOrientation;
+}
+
+export function Divider({
+  orientation = 'horizontal',
+  className,
+  ...props
+}: DividerProps) {
+  const classNames = [styles.divider, styles[orientation], className]
+    .filter(Boolean)
+    .join(' ');
+
+  return <hr className={classNames} {...props} />;
+}
+
+export default Divider;

--- a/src/components/ui/Spinner.module.css
+++ b/src/components/ui/Spinner.module.css
@@ -1,0 +1,60 @@
+.spinner {
+  display: inline-block;
+  border-radius: 50%;
+  border-style: solid;
+  border-color: var(--color-primary-500) transparent transparent transparent;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+/* Sizes */
+.xs {
+  width: 12px;
+  height: 12px;
+  border-width: 2px;
+}
+
+.sm {
+  width: 16px;
+  height: 16px;
+  border-width: 2px;
+}
+
+.md {
+  width: 24px;
+  height: 24px;
+  border-width: 3px;
+}
+
+.lg {
+  width: 32px;
+  height: 32px;
+  border-width: 3px;
+}
+
+.xl {
+  width: 48px;
+  height: 48px;
+  border-width: 4px;
+}
+
+/* Screen reader only */
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/src/components/ui/Spinner.tsx
+++ b/src/components/ui/Spinner.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import styles from './Spinner.module.css';
+
+export type SpinnerSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+
+export interface SpinnerProps extends React.HTMLAttributes<HTMLDivElement> {
+  size?: SpinnerSize;
+  color?: string;
+  thickness?: string;
+  speed?: string;
+  label?: string;
+}
+
+export function Spinner({
+  size = 'md',
+  color,
+  thickness,
+  speed,
+  label = 'Loading...',
+  className,
+  style,
+  ...props
+}: SpinnerProps) {
+  const classNames = [styles.spinner, styles[size], className]
+    .filter(Boolean)
+    .join(' ');
+
+  const customStyle: React.CSSProperties = {
+    ...(color && { borderColor: `${color} transparent transparent transparent` }),
+    ...(thickness && { borderWidth: thickness }),
+    ...(speed && { animationDuration: speed }),
+    ...style,
+  };
+
+  return (
+    <div className={classNames} style={customStyle} role="status" {...props}>
+      <span className={styles.srOnly}>{label}</span>
+    </div>
+  );
+}
+
+export default Spinner;

--- a/src/components/ui/__stories__/Alert.stories.tsx
+++ b/src/components/ui/__stories__/Alert.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Alert, AlertIcon, AlertTitle, AlertDescription } from '../Alert';
+import { VStack } from '../';
+
+const meta: Meta<typeof Alert> = {
+  title: 'Display/Alert',
+  component: Alert,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Alert>;
+
+export const Default: Story = {
+  render: () => (
+    <Alert>
+      <AlertIcon />
+      <AlertTitle>Info Alert</AlertTitle>
+      <AlertDescription>This is an informational alert.</AlertDescription>
+    </Alert>
+  ),
+};
+
+export const Statuses: Story = {
+  render: () => (
+    <VStack spacing={4} align="stretch">
+      <Alert status="info">
+        <AlertIcon status="info" />
+        <AlertTitle>Info</AlertTitle>
+        <AlertDescription>This is an info alert.</AlertDescription>
+      </Alert>
+      <Alert status="warning">
+        <AlertIcon status="warning" />
+        <AlertTitle>Warning</AlertTitle>
+        <AlertDescription>This is a warning alert.</AlertDescription>
+      </Alert>
+      <Alert status="success">
+        <AlertIcon status="success" />
+        <AlertTitle>Success</AlertTitle>
+        <AlertDescription>This is a success alert.</AlertDescription>
+      </Alert>
+      <Alert status="error">
+        <AlertIcon status="error" />
+        <AlertTitle>Error</AlertTitle>
+        <AlertDescription>This is an error alert.</AlertDescription>
+      </Alert>
+    </VStack>
+  ),
+};

--- a/src/components/ui/__stories__/Avatar.stories.tsx
+++ b/src/components/ui/__stories__/Avatar.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Avatar, AvatarGroup } from '../Avatar';
+import { HStack } from '../';
+
+const meta: Meta<typeof Avatar> = {
+  title: 'Display/Avatar',
+  component: Avatar,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Avatar>;
+
+export const Default: Story = {
+  args: {
+    name: 'John Doe',
+  },
+};
+
+export const WithImage: Story = {
+  args: {
+    src: 'https://i.pravatar.cc/150?img=1',
+    name: 'John Doe',
+  },
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <HStack spacing={4}>
+      <Avatar size="xs" name="XS" />
+      <Avatar size="sm" name="SM" />
+      <Avatar size="md" name="MD" />
+      <Avatar size="lg" name="LG" />
+      <Avatar size="xl" name="XL" />
+      <Avatar size="2xl" name="2XL" />
+    </HStack>
+  ),
+};
+
+export const Initials: Story = {
+  render: () => (
+    <HStack spacing={4}>
+      <Avatar name="John Doe" />
+      <Avatar name="Jane Smith" />
+      <Avatar name="Bob" />
+    </HStack>
+  ),
+};
+
+export const Fallback: Story = {
+  render: () => <Avatar />,
+};
+
+export const Group: Story = {
+  render: () => (
+    <AvatarGroup max={3}>
+      <Avatar name="John Doe" />
+      <Avatar name="Jane Smith" />
+      <Avatar name="Bob Wilson" />
+      <Avatar name="Alice Brown" />
+      <Avatar name="Charlie Davis" />
+    </AvatarGroup>
+  ),
+};

--- a/src/components/ui/__stories__/Badge.stories.tsx
+++ b/src/components/ui/__stories__/Badge.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Badge } from '../Badge';
+import { HStack, VStack } from '../';
+
+const meta: Meta<typeof Badge> = {
+  title: 'Display/Badge',
+  component: Badge,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Badge>;
+
+export const Default: Story = {
+  args: {
+    children: 'Badge',
+  },
+};
+
+export const Variants: Story = {
+  render: () => (
+    <HStack spacing={4}>
+      <Badge variant="solid">Solid</Badge>
+      <Badge variant="subtle">Subtle</Badge>
+      <Badge variant="outline">Outline</Badge>
+    </HStack>
+  ),
+};
+
+export const ColorSchemes: Story = {
+  render: () => (
+    <VStack spacing={4} align="flex-start">
+      <HStack spacing={2}>
+        <Badge colorScheme="gray">Gray</Badge>
+        <Badge colorScheme="primary">Primary</Badge>
+        <Badge colorScheme="green">Green</Badge>
+        <Badge colorScheme="red">Red</Badge>
+        <Badge colorScheme="yellow">Yellow</Badge>
+        <Badge colorScheme="blue">Blue</Badge>
+        <Badge colorScheme="purple">Purple</Badge>
+      </HStack>
+      <HStack spacing={2}>
+        <Badge variant="solid" colorScheme="gray">Gray</Badge>
+        <Badge variant="solid" colorScheme="primary">Primary</Badge>
+        <Badge variant="solid" colorScheme="green">Green</Badge>
+        <Badge variant="solid" colorScheme="red">Red</Badge>
+        <Badge variant="solid" colorScheme="yellow">Yellow</Badge>
+        <Badge variant="solid" colorScheme="blue">Blue</Badge>
+        <Badge variant="solid" colorScheme="purple">Purple</Badge>
+      </HStack>
+    </VStack>
+  ),
+};

--- a/src/components/ui/__stories__/Card.stories.tsx
+++ b/src/components/ui/__stories__/Card.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Card, CardHeader, CardBody, CardFooter } from '../Card';
+import { Heading, Text, Button, HStack, VStack } from '../';
+
+const meta: Meta<typeof Card> = {
+  title: 'Display/Card',
+  component: Card,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Card>;
+
+export const Default: Story = {
+  render: () => (
+    <Card style={{ maxWidth: '320px' }}>
+      <CardHeader>
+        <Heading size="md">Card Title</Heading>
+      </CardHeader>
+      <CardBody>
+        <Text>This is the card body content. You can put any content here.</Text>
+      </CardBody>
+      <CardFooter>
+        <Button>Action</Button>
+      </CardFooter>
+    </Card>
+  ),
+};
+
+export const Variants: Story = {
+  render: () => (
+    <HStack spacing={4} align="flex-start">
+      <Card variant="elevated" style={{ width: '200px' }}>
+        <CardBody>
+          <Text>Elevated</Text>
+        </CardBody>
+      </Card>
+      <Card variant="outline" style={{ width: '200px' }}>
+        <CardBody>
+          <Text>Outline</Text>
+        </CardBody>
+      </Card>
+      <Card variant="filled" style={{ width: '200px' }}>
+        <CardBody>
+          <Text>Filled</Text>
+        </CardBody>
+      </Card>
+    </HStack>
+  ),
+};
+
+export const Hoverable: Story = {
+  render: () => (
+    <Card isHoverable style={{ maxWidth: '320px' }}>
+      <CardBody>
+        <Text>Hover over me!</Text>
+      </CardBody>
+    </Card>
+  ),
+};

--- a/src/components/ui/__stories__/Divider.stories.tsx
+++ b/src/components/ui/__stories__/Divider.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Divider } from '../Divider';
+import { Box, VStack, HStack, Text } from '../';
+
+const meta: Meta<typeof Divider> = {
+  title: 'Display/Divider',
+  component: Divider,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Divider>;
+
+export const Horizontal: Story = {
+  render: () => (
+    <VStack spacing={4} align="stretch" style={{ width: '300px' }}>
+      <Text>Above the divider</Text>
+      <Divider />
+      <Text>Below the divider</Text>
+    </VStack>
+  ),
+};
+
+export const Vertical: Story = {
+  render: () => (
+    <HStack spacing={4} style={{ height: '50px' }}>
+      <Text>Left</Text>
+      <Divider orientation="vertical" />
+      <Text>Right</Text>
+    </HStack>
+  ),
+};

--- a/src/components/ui/__stories__/Spinner.stories.tsx
+++ b/src/components/ui/__stories__/Spinner.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Spinner } from '../Spinner';
+import { HStack } from '../';
+
+const meta: Meta<typeof Spinner> = {
+  title: 'Display/Spinner',
+  component: Spinner,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Spinner>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <HStack spacing={4}>
+      <Spinner size="xs" />
+      <Spinner size="sm" />
+      <Spinner size="md" />
+      <Spinner size="lg" />
+      <Spinner size="xl" />
+    </HStack>
+  ),
+};
+
+export const CustomColor: Story = {
+  args: {
+    color: 'var(--color-primary-500)',
+  },
+};

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -16,7 +16,13 @@ export { Checkbox } from './Checkbox';
 export { Switch } from './Switch';
 export { FormControl, FormLabel, FormErrorMessage, FormHelperText } from './FormControl';
 
-export { default as Card } from './Card';
+export { Badge } from './Badge';
+export { Avatar, AvatarGroup } from './Avatar';
+export { Card, CardHeader, CardBody, CardFooter } from './Card';
+export { Alert, AlertIcon, AlertTitle, AlertDescription } from './Alert';
+export { Spinner } from './Spinner';
+export { Divider } from './Divider';
+
 export { default as ProgressBar } from './ProgressBar';
 export { default as EmptyState } from './EmptyState';
 export { default as StatusBadge } from './StatusBadge';
@@ -42,3 +48,10 @@ export type { FormControlProps, FormLabelProps, FormErrorMessageProps, FormHelpe
 export type { TaskStatus, ProjectStatus, UserStatus } from './StatusBadge';
 export type { Priority } from './PriorityBadge';
 export type { Role } from './RoleBadge';
+
+export type { BadgeProps, BadgeVariant, BadgeColorScheme } from './Badge';
+export type { AvatarProps, AvatarSize, AvatarGroupProps } from './Avatar';
+export type { CardProps, CardVariant, CardHeaderProps, CardBodyProps, CardFooterProps } from './Card';
+export type { AlertProps, AlertStatus, AlertIconProps, AlertTitleProps, AlertDescriptionProps } from './Alert';
+export type { SpinnerProps, SpinnerSize } from './Spinner';
+export type { DividerProps, DividerOrientation } from './Divider';


### PR DESCRIPTION
## Summary
- Badge, Avatar (AvatarGroup含む), Card, Alert, Spinner, Dividerコンポーネントを実装
- CSS Modulesベースのスタイリング
- Storybookストーリーを追加
- 名前競合解決のためcommon/AlertをAnimatedAlertにリネーム

## Test plan
- [ ] `npm run build` でビルド成功を確認
- [ ] Storybookで各コンポーネントの表示確認

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)