### PR TITLE
feat: Modal、TooltipコンポーネントをCSS Modulesで実装 (#116)

### DIFF
--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -2,5 +2,5 @@ export { default as PageHeader } from './PageHeader';
 export { default as ActionMenu } from './ActionMenu';
 export { default as UserAvatar } from './UserAvatar';
 export { default as FilterBar } from './FilterBar';
-export { default as Tooltip } from './Tooltip';
+export { default as ChakraTooltip } from './Tooltip';
 export { default as AnimatedAlert } from './Alert';

--- a/src/components/ui/Modal.module.css
+++ b/src/components/ui/Modal.module.css
@@ -1,0 +1,112 @@
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+  display: flex;
+  padding: var(--spacing-4);
+  overflow-y: auto;
+}
+
+.overlay.centered {
+  align-items: center;
+  justify-content: center;
+}
+
+.content {
+  background-color: white;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-xl);
+  max-height: calc(100vh - var(--spacing-8));
+  display: flex;
+  flex-direction: column;
+  animation: modalEnter 0.2s ease-out;
+}
+
+@keyframes modalEnter {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.sm {
+  width: 100%;
+  max-width: 320px;
+}
+
+.md {
+  width: 100%;
+  max-width: 448px;
+}
+
+.lg {
+  width: 100%;
+  max-width: 512px;
+}
+
+.xl {
+  width: 100%;
+  max-width: 768px;
+}
+
+.full {
+  width: 100%;
+  max-width: calc(100vw - var(--spacing-8));
+  max-height: calc(100vh - var(--spacing-8));
+}
+
+.header {
+  padding: var(--spacing-4) var(--spacing-6);
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  border-bottom: 1px solid var(--color-gray-200);
+  position: relative;
+}
+
+.body {
+  padding: var(--spacing-4) var(--spacing-6);
+  flex: 1;
+  overflow-y: auto;
+}
+
+.footer {
+  padding: var(--spacing-4) var(--spacing-6);
+  border-top: 1px solid var(--color-gray-200);
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-3);
+}
+
+.closeButton {
+  position: absolute;
+  top: var(--spacing-3);
+  right: var(--spacing-3);
+  padding: var(--spacing-1);
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-gray-500);
+  border-radius: var(--radius-md);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color var(--transition-fast), color var(--transition-fast);
+}
+
+.closeButton:hover {
+  background-color: var(--color-gray-100);
+  color: var(--color-gray-700);
+}
+
+.closeButton:focus-visible {
+  outline: 2px solid var(--color-primary-500);
+  outline-offset: 2px;
+}

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,0 +1,121 @@
+import React, { useEffect, useRef, useCallback } from 'react';
+import { createPortal } from 'react-dom';
+import styles from './Modal.module.css';
+
+export type ModalSize = 'sm' | 'md' | 'lg' | 'xl' | 'full';
+
+export interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+  size?: ModalSize;
+  isCentered?: boolean;
+  closeOnOverlayClick?: boolean;
+  closeOnEsc?: boolean;
+}
+
+export function Modal({
+  isOpen,
+  onClose,
+  children,
+  size = 'md',
+  isCentered = true,
+  closeOnOverlayClick = true,
+  closeOnEsc = true,
+}: ModalProps) {
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (closeOnEsc && event.key === 'Escape') {
+        onClose();
+      }
+    },
+    [closeOnEsc, onClose]
+  );
+
+  const handleOverlayClick = useCallback(
+    (event: React.MouseEvent) => {
+      if (closeOnOverlayClick && event.target === overlayRef.current) {
+        onClose();
+      }
+    },
+    [closeOnOverlayClick, onClose]
+  );
+
+  useEffect(() => {
+    if (isOpen) {
+      document.addEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = 'hidden';
+    }
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = '';
+    };
+  }, [isOpen, handleKeyDown]);
+
+  if (!isOpen) return null;
+
+  const modalContent = (
+    <div
+      ref={overlayRef}
+      className={`${styles.overlay} ${isCentered ? styles.centered : ''}`}
+      onClick={handleOverlayClick}
+      role="dialog"
+      aria-modal="true"
+    >
+      <div className={`${styles.content} ${styles[size]}`}>{children}</div>
+    </div>
+  );
+
+  return createPortal(modalContent, document.body);
+}
+
+export interface ModalHeaderProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function ModalHeader({ className, children, ...props }: ModalHeaderProps) {
+  const classNames = [styles.header, className].filter(Boolean).join(' ');
+  return (
+    <div className={classNames} {...props}>
+      {children}
+    </div>
+  );
+}
+
+export interface ModalBodyProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function ModalBody({ className, children, ...props }: ModalBodyProps) {
+  const classNames = [styles.body, className].filter(Boolean).join(' ');
+  return (
+    <div className={classNames} {...props}>
+      {children}
+    </div>
+  );
+}
+
+export interface ModalFooterProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function ModalFooter({ className, children, ...props }: ModalFooterProps) {
+  const classNames = [styles.footer, className].filter(Boolean).join(' ');
+  return (
+    <div className={classNames} {...props}>
+      {children}
+    </div>
+  );
+}
+
+export interface ModalCloseButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+
+export function ModalCloseButton({ className, onClick, ...props }: ModalCloseButtonProps) {
+  const classNames = [styles.closeButton, className].filter(Boolean).join(' ');
+  return (
+    <button type="button" className={classNames} aria-label="Close" onClick={onClick} {...props}>
+      <svg viewBox="0 0 24 24" fill="currentColor" width="20" height="20">
+        <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
+      </svg>
+    </button>
+  );
+}
+
+export default Modal;

--- a/src/components/ui/Tooltip.module.css
+++ b/src/components/ui/Tooltip.module.css
@@ -1,0 +1,62 @@
+.tooltip {
+  position: absolute;
+  z-index: 1100;
+  padding: var(--spacing-2) var(--spacing-3);
+  background-color: var(--color-gray-700);
+  color: white;
+  font-size: var(--font-size-sm);
+  border-radius: var(--radius-md);
+  max-width: 320px;
+  word-wrap: break-word;
+  animation: tooltipEnter 0.15s ease-out;
+  pointer-events: none;
+}
+
+@keyframes tooltipEnter {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.hasArrow::after {
+  content: '';
+  position: absolute;
+  border: 6px solid transparent;
+}
+
+.top.hasArrow::after {
+  bottom: -12px;
+  left: 50%;
+  transform: translateX(-50%);
+  border-top-color: var(--color-gray-700);
+}
+
+.bottom.hasArrow::after {
+  top: -12px;
+  left: 50%;
+  transform: translateX(-50%);
+  border-bottom-color: var(--color-gray-700);
+}
+
+.left.hasArrow::after {
+  right: -12px;
+  top: 50%;
+  transform: translateY(-50%);
+  border-left-color: var(--color-gray-700);
+}
+
+.right.hasArrow::after {
+  left: -12px;
+  top: 50%;
+  transform: translateY(-50%);
+  border-right-color: var(--color-gray-700);
+}
+
+.trigger {
+  display: inline-block;
+}

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -1,0 +1,120 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import styles from './Tooltip.module.css';
+
+export type TooltipPlacement = 'top' | 'bottom' | 'left' | 'right';
+
+export interface TooltipProps {
+  children: React.ReactNode;
+  content: React.ReactNode;
+  placement?: TooltipPlacement;
+  hasArrow?: boolean;
+  isDisabled?: boolean;
+  openDelay?: number;
+  closeDelay?: number;
+}
+
+export function Tooltip({
+  children,
+  content,
+  placement = 'top',
+  hasArrow = true,
+  isDisabled = false,
+  openDelay = 0,
+  closeDelay = 0,
+}: TooltipProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [position, setPosition] = useState({ top: 0, left: 0 });
+  const triggerRef = useRef<HTMLElement>(null);
+  const tooltipRef = useRef<HTMLDivElement>(null);
+  const openTimeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const closeTimeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const updatePosition = () => {
+    if (!triggerRef.current || !tooltipRef.current) return;
+
+    const triggerRect = triggerRef.current.getBoundingClientRect();
+    const tooltipRect = tooltipRef.current.getBoundingClientRect();
+    const offset = 8;
+
+    let top = 0;
+    let left = 0;
+
+    switch (placement) {
+      case 'top':
+        top = triggerRect.top - tooltipRect.height - offset;
+        left = triggerRect.left + (triggerRect.width - tooltipRect.width) / 2;
+        break;
+      case 'bottom':
+        top = triggerRect.bottom + offset;
+        left = triggerRect.left + (triggerRect.width - tooltipRect.width) / 2;
+        break;
+      case 'left':
+        top = triggerRect.top + (triggerRect.height - tooltipRect.height) / 2;
+        left = triggerRect.left - tooltipRect.width - offset;
+        break;
+      case 'right':
+        top = triggerRect.top + (triggerRect.height - tooltipRect.height) / 2;
+        left = triggerRect.right + offset;
+        break;
+    }
+
+    top = Math.max(8, Math.min(top, window.innerHeight - tooltipRect.height - 8));
+    left = Math.max(8, Math.min(left, window.innerWidth - tooltipRect.width - 8));
+
+    setPosition({ top: top + window.scrollY, left: left + window.scrollX });
+  };
+
+  useEffect(() => {
+    if (isOpen) {
+      updatePosition();
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    return () => {
+      if (openTimeoutRef.current) clearTimeout(openTimeoutRef.current);
+      if (closeTimeoutRef.current) clearTimeout(closeTimeoutRef.current);
+    };
+  }, []);
+
+  const handleOpen = () => {
+    if (isDisabled) return;
+    if (closeTimeoutRef.current) clearTimeout(closeTimeoutRef.current);
+    openTimeoutRef.current = setTimeout(() => setIsOpen(true), openDelay);
+  };
+
+  const handleClose = () => {
+    if (openTimeoutRef.current) clearTimeout(openTimeoutRef.current);
+    closeTimeoutRef.current = setTimeout(() => setIsOpen(false), closeDelay);
+  };
+
+  const tooltipElement = isOpen && (
+    <div
+      ref={tooltipRef}
+      className={`${styles.tooltip} ${styles[placement]} ${hasArrow ? styles.hasArrow : ''}`}
+      style={{ top: position.top, left: position.left }}
+      role="tooltip"
+    >
+      {content}
+    </div>
+  );
+
+  return (
+    <>
+      <span
+        ref={triggerRef}
+        onMouseEnter={handleOpen}
+        onMouseLeave={handleClose}
+        onFocus={handleOpen}
+        onBlur={handleClose}
+        className={styles.trigger}
+      >
+        {children}
+      </span>
+      {typeof document !== 'undefined' && createPortal(tooltipElement, document.body)}
+    </>
+  );
+}
+
+export default Tooltip;

--- a/src/components/ui/__stories__/Modal.stories.tsx
+++ b/src/components/ui/__stories__/Modal.stories.tsx
@@ -1,0 +1,79 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { Modal, ModalHeader, ModalBody, ModalFooter, ModalCloseButton } from '../Modal';
+import { Button, Text } from '../';
+
+const meta: Meta<typeof Modal> = {
+  title: 'Overlay/Modal',
+  component: Modal,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Modal>;
+
+function ModalDemo() {
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setIsOpen(true)}>Open Modal</Button>
+      <Modal isOpen={isOpen} onClose={() => setIsOpen(false)}>
+        <ModalHeader>
+          Modal Title
+          <ModalCloseButton onClick={() => setIsOpen(false)} />
+        </ModalHeader>
+        <ModalBody>
+          <Text>This is the modal content. You can put any content here.</Text>
+        </ModalBody>
+        <ModalFooter>
+          <Button variant="ghost" onClick={() => setIsOpen(false)}>
+            Cancel
+          </Button>
+          <Button onClick={() => setIsOpen(false)}>Confirm</Button>
+        </ModalFooter>
+      </Modal>
+    </>
+  );
+}
+
+export const Default: Story = {
+  render: () => <ModalDemo />,
+};
+
+function SizesDemo() {
+  const [size, setSize] = useState<'sm' | 'md' | 'lg' | 'xl'>('md');
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+      {(['sm', 'md', 'lg', 'xl'] as const).map((s) => (
+        <Button
+          key={s}
+          variant="outline"
+          onClick={() => {
+            setSize(s);
+            setIsOpen(true);
+          }}
+        >
+          {s.toUpperCase()}
+        </Button>
+      ))}
+      <Modal isOpen={isOpen} onClose={() => setIsOpen(false)} size={size}>
+        <ModalHeader>
+          {size.toUpperCase()} Modal
+          <ModalCloseButton onClick={() => setIsOpen(false)} />
+        </ModalHeader>
+        <ModalBody>
+          <Text>This is a {size} sized modal.</Text>
+        </ModalBody>
+        <ModalFooter>
+          <Button onClick={() => setIsOpen(false)}>Close</Button>
+        </ModalFooter>
+      </Modal>
+    </div>
+  );
+}
+
+export const Sizes: Story = {
+  render: () => <SizesDemo />,
+};

--- a/src/components/ui/__stories__/Tooltip.stories.tsx
+++ b/src/components/ui/__stories__/Tooltip.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Tooltip } from '../Tooltip';
+import { Button, HStack, VStack } from '../';
+
+const meta: Meta<typeof Tooltip> = {
+  title: 'Overlay/Tooltip',
+  component: Tooltip,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Tooltip>;
+
+export const Default: Story = {
+  render: () => (
+    <div style={{ padding: '100px' }}>
+      <Tooltip content="This is a tooltip">
+        <Button>Hover me</Button>
+      </Tooltip>
+    </div>
+  ),
+};
+
+export const Placements: Story = {
+  render: () => (
+    <div style={{ padding: '100px', display: 'flex', justifyContent: 'center' }}>
+      <VStack spacing={8}>
+        <Tooltip content="Top tooltip" placement="top">
+          <Button>Top</Button>
+        </Tooltip>
+        <HStack spacing={8}>
+          <Tooltip content="Left tooltip" placement="left">
+            <Button>Left</Button>
+          </Tooltip>
+          <Tooltip content="Right tooltip" placement="right">
+            <Button>Right</Button>
+          </Tooltip>
+        </HStack>
+        <Tooltip content="Bottom tooltip" placement="bottom">
+          <Button>Bottom</Button>
+        </Tooltip>
+      </VStack>
+    </div>
+  ),
+};
+
+export const WithoutArrow: Story = {
+  render: () => (
+    <div style={{ padding: '100px' }}>
+      <Tooltip content="No arrow" hasArrow={false}>
+        <Button>Hover me</Button>
+      </Tooltip>
+    </div>
+  ),
+};

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -22,6 +22,8 @@ export { Card, CardHeader, CardBody, CardFooter } from './Card';
 export { Alert, AlertIcon, AlertTitle, AlertDescription } from './Alert';
 export { Spinner } from './Spinner';
 export { Divider } from './Divider';
+export { Modal, ModalHeader, ModalBody, ModalFooter, ModalCloseButton } from './Modal';
+export { Tooltip } from './Tooltip';
 
 export { default as ProgressBar } from './ProgressBar';
 export { default as EmptyState } from './EmptyState';
@@ -55,3 +57,5 @@ export type { CardProps, CardVariant, CardHeaderProps, CardBodyProps, CardFooter
 export type { AlertProps, AlertStatus, AlertIconProps, AlertTitleProps, AlertDescriptionProps } from './Alert';
 export type { SpinnerProps, SpinnerSize } from './Spinner';
 export type { DividerProps, DividerOrientation } from './Divider';
+export type { ModalProps, ModalSize, ModalHeaderProps, ModalBodyProps, ModalFooterProps, ModalCloseButtonProps } from './Modal';
+export type { TooltipProps, TooltipPlacement } from './Tooltip';


### PR DESCRIPTION
## Summary
- Modal コンポーネント（Portal使用、ESCキー/オーバーレイクリックで閉じる）
- Tooltip コンポーネント（ホバー/フォーカスで表示、4方向対応）
- Storybookストーリー追加
- 名前競合解決のためcommon/TooltipをChakraTooltipにリネーム

## Test plan
- [ ] `npm run build` でビルド成功を確認
- [ ] Storybookで各コンポーネントの表示確認

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)