### PR TITLE
feat: Menu、TabsコンポーネントをCSS Modulesで実装 (#117)

### DIFF
--- a/src/components/ui/Menu.module.css
+++ b/src/components/ui/Menu.module.css
@@ -1,0 +1,90 @@
+.menu {
+  position: relative;
+  display: inline-block;
+}
+
+.menuButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-2);
+  background: none;
+  border: none;
+  cursor: pointer;
+  border-radius: var(--radius-md);
+  color: var(--color-gray-600);
+  transition: background-color var(--transition-fast), color var(--transition-fast);
+}
+
+.menuButton:hover {
+  background-color: var(--color-gray-100);
+  color: var(--color-gray-800);
+}
+
+.menuButton:focus-visible {
+  outline: 2px solid var(--color-primary-500);
+  outline-offset: 2px;
+}
+
+.menuList {
+  position: absolute;
+  z-index: 1000;
+  min-width: 160px;
+  padding: var(--spacing-1) 0;
+  background-color: white;
+  border: 1px solid var(--color-gray-200);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+  animation: menuEnter 0.15s ease-out;
+}
+
+@keyframes menuEnter {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.menuItem {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: var(--spacing-2) var(--spacing-3);
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+  color: var(--color-gray-700);
+  text-align: left;
+  transition: background-color var(--transition-fast);
+}
+
+.menuItem:hover {
+  background-color: var(--color-gray-100);
+}
+
+.menuItem:focus-visible {
+  outline: none;
+  background-color: var(--color-gray-100);
+}
+
+.menuItem:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.menuItemIcon {
+  display: flex;
+  margin-right: var(--spacing-2);
+  color: var(--color-gray-500);
+}
+
+.menuDivider {
+  margin: var(--spacing-1) 0;
+  border: none;
+  border-top: 1px solid var(--color-gray-200);
+}

--- a/src/components/ui/Menu.tsx
+++ b/src/components/ui/Menu.tsx
@@ -1,0 +1,166 @@
+import React, { createContext, useContext, useState, useRef, useEffect, useCallback } from 'react';
+import { createPortal } from 'react-dom';
+import styles from './Menu.module.css';
+
+interface MenuContextValue {
+  isOpen: boolean;
+  onOpen: () => void;
+  onClose: () => void;
+  triggerRef: React.RefObject<HTMLButtonElement | null>;
+}
+
+const MenuContext = createContext<MenuContextValue | null>(null);
+
+function useMenuContext() {
+  const context = useContext(MenuContext);
+  if (!context) {
+    throw new Error('Menu components must be used within a Menu');
+  }
+  return context;
+}
+
+export interface MenuProps {
+  children: React.ReactNode;
+}
+
+export function Menu({ children }: MenuProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  const onOpen = useCallback(() => setIsOpen(true), []);
+  const onClose = useCallback(() => setIsOpen(false), []);
+
+  return (
+    <MenuContext.Provider value={{ isOpen, onOpen, onClose, triggerRef }}>
+      <div className={styles.menu}>{children}</div>
+    </MenuContext.Provider>
+  );
+}
+
+export interface MenuButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+
+export function MenuButton({ children, className, onClick, ...props }: MenuButtonProps) {
+  const { isOpen, onOpen, onClose, triggerRef } = useMenuContext();
+
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    if (isOpen) {
+      onClose();
+    } else {
+      onOpen();
+    }
+    onClick?.(e);
+  };
+
+  const classNames = [styles.menuButton, className].filter(Boolean).join(' ');
+
+  return (
+    <button
+      ref={triggerRef}
+      type="button"
+      className={classNames}
+      onClick={handleClick}
+      aria-expanded={isOpen}
+      aria-haspopup="menu"
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}
+
+export interface MenuListProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function MenuList({ children, className, ...props }: MenuListProps) {
+  const { isOpen, onClose, triggerRef } = useMenuContext();
+  const listRef = useRef<HTMLDivElement>(null);
+  const [position, setPosition] = useState({ top: 0, left: 0 });
+
+  useEffect(() => {
+    if (isOpen && triggerRef.current) {
+      const rect = triggerRef.current.getBoundingClientRect();
+      setPosition({
+        top: rect.bottom + window.scrollY + 4,
+        left: rect.left + window.scrollX,
+      });
+    }
+  }, [isOpen, triggerRef]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleClickOutside = (e: MouseEvent) => {
+      if (
+        listRef.current &&
+        !listRef.current.contains(e.target as Node) &&
+        triggerRef.current &&
+        !triggerRef.current.contains(e.target as Node)
+      ) {
+        onClose();
+      }
+    };
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+        triggerRef.current?.focus();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen, onClose, triggerRef]);
+
+  if (!isOpen) return null;
+
+  const classNames = [styles.menuList, className].filter(Boolean).join(' ');
+
+  const menuList = (
+    <div
+      ref={listRef}
+      className={classNames}
+      role="menu"
+      style={{ top: position.top, left: position.left }}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+
+  return createPortal(menuList, document.body);
+}
+
+export interface MenuItemProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  icon?: React.ReactNode;
+}
+
+export function MenuItem({ children, className, icon, onClick, ...props }: MenuItemProps) {
+  const { onClose } = useMenuContext();
+
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    onClick?.(e);
+    onClose();
+  };
+
+  const classNames = [styles.menuItem, className].filter(Boolean).join(' ');
+
+  return (
+    <button type="button" className={classNames} role="menuitem" onClick={handleClick} {...props}>
+      {icon && <span className={styles.menuItemIcon}>{icon}</span>}
+      {children}
+    </button>
+  );
+}
+
+export interface MenuDividerProps extends React.HTMLAttributes<HTMLHRElement> {}
+
+export function MenuDivider({ className, ...props }: MenuDividerProps) {
+  const classNames = [styles.menuDivider, className].filter(Boolean).join(' ');
+  return <hr className={classNames} {...props} />;
+}
+
+export default Menu;

--- a/src/components/ui/Tabs.module.css
+++ b/src/components/ui/Tabs.module.css
@@ -1,0 +1,103 @@
+.tabs {
+  width: 100%;
+}
+
+.tabList {
+  display: flex;
+  gap: var(--spacing-1);
+}
+
+.tabList.line {
+  border-bottom: 2px solid var(--color-gray-200);
+}
+
+.tabList.enclosed {
+  border-bottom: 1px solid var(--color-gray-200);
+}
+
+.tabList.soft-rounded {
+  gap: var(--spacing-2);
+}
+
+.tab {
+  padding: var(--spacing-2) var(--spacing-4);
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-gray-600);
+  transition: color var(--transition-fast), background-color var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.tab:focus-visible {
+  outline: 2px solid var(--color-primary-500);
+  outline-offset: 2px;
+}
+
+.tab.disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.tab.line {
+  margin-bottom: -2px;
+  border-bottom: 2px solid transparent;
+}
+
+.tab.line:hover:not(.disabled) {
+  color: var(--color-primary-600);
+}
+
+.tab.line.active {
+  color: var(--color-primary-600);
+  border-bottom-color: var(--color-primary-500);
+}
+
+.tab.enclosed {
+  border: 1px solid transparent;
+  border-bottom: none;
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
+  margin-bottom: -1px;
+}
+
+.tab.enclosed:hover:not(.disabled) {
+  background-color: var(--color-gray-100);
+}
+
+.tab.enclosed.active {
+  background-color: white;
+  border-color: var(--color-gray-200);
+  color: var(--color-primary-600);
+}
+
+.tab.soft-rounded {
+  border-radius: var(--radius-full);
+}
+
+.tab.soft-rounded:hover:not(.disabled) {
+  background-color: var(--color-gray-100);
+}
+
+.tab.soft-rounded.active {
+  background-color: var(--color-primary-100);
+  color: var(--color-primary-700);
+}
+
+.tabPanels {
+  padding-top: var(--spacing-4);
+}
+
+.tabPanel {
+  animation: tabPanelEnter 0.2s ease-out;
+}
+
+@keyframes tabPanelEnter {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}

--- a/src/components/ui/Tabs.tsx
+++ b/src/components/ui/Tabs.tsx
@@ -1,0 +1,148 @@
+import React, { createContext, useContext, useState } from 'react';
+import styles from './Tabs.module.css';
+
+interface TabsContextValue {
+  activeIndex: number;
+  setActiveIndex: (index: number) => void;
+  variant: TabsVariant;
+}
+
+const TabsContext = createContext<TabsContextValue | null>(null);
+
+function useTabsContext() {
+  const context = useContext(TabsContext);
+  if (!context) {
+    throw new Error('Tabs components must be used within a Tabs');
+  }
+  return context;
+}
+
+export type TabsVariant = 'line' | 'enclosed' | 'soft-rounded';
+
+export interface TabsProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'> {
+  defaultIndex?: number;
+  index?: number;
+  onChange?: (index: number) => void;
+  variant?: TabsVariant;
+}
+
+export function Tabs({
+  children,
+  className,
+  defaultIndex = 0,
+  index,
+  onChange,
+  variant = 'line',
+  ...props
+}: TabsProps) {
+  const [internalIndex, setInternalIndex] = useState(defaultIndex);
+
+  const activeIndex = index !== undefined ? index : internalIndex;
+
+  const setActiveIndex = (newIndex: number) => {
+    if (index === undefined) {
+      setInternalIndex(newIndex);
+    }
+    onChange?.(newIndex);
+  };
+
+  const classNames = [styles.tabs, className].filter(Boolean).join(' ');
+
+  return (
+    <TabsContext.Provider value={{ activeIndex, setActiveIndex, variant }}>
+      <div className={classNames} {...props}>
+        {children}
+      </div>
+    </TabsContext.Provider>
+  );
+}
+
+export interface TabListProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function TabList({ children, className, ...props }: TabListProps) {
+  const { variant } = useTabsContext();
+  const classNames = [styles.tabList, styles[variant], className].filter(Boolean).join(' ');
+
+  return (
+    <div className={classNames} role="tablist" {...props}>
+      {React.Children.map(children, (child, index) =>
+        React.isValidElement(child)
+          ? React.cloneElement(child, { index } as { index: number })
+          : child
+      )}
+    </div>
+  );
+}
+
+export interface TabProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  index?: number;
+  isDisabled?: boolean;
+}
+
+export function Tab({ children, className, index = 0, isDisabled = false, ...props }: TabProps) {
+  const { activeIndex, setActiveIndex, variant } = useTabsContext();
+  const isActive = activeIndex === index;
+
+  const classNames = [
+    styles.tab,
+    styles[variant],
+    isActive ? styles.active : '',
+    isDisabled ? styles.disabled : '',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <button
+      type="button"
+      role="tab"
+      className={classNames}
+      aria-selected={isActive}
+      disabled={isDisabled}
+      onClick={() => !isDisabled && setActiveIndex(index)}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}
+
+export interface TabPanelsProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function TabPanels({ children, className, ...props }: TabPanelsProps) {
+  const { activeIndex } = useTabsContext();
+  const classNames = [styles.tabPanels, className].filter(Boolean).join(' ');
+
+  return (
+    <div className={classNames} {...props}>
+      {React.Children.map(children, (child, index) =>
+        React.isValidElement(child)
+          ? React.cloneElement(child, { index, isActive: activeIndex === index } as {
+              index: number;
+              isActive: boolean;
+            })
+          : child
+      )}
+    </div>
+  );
+}
+
+export interface TabPanelProps extends React.HTMLAttributes<HTMLDivElement> {
+  index?: number;
+  isActive?: boolean;
+}
+
+export function TabPanel({ children, className, isActive = false, ...props }: TabPanelProps) {
+  const classNames = [styles.tabPanel, className].filter(Boolean).join(' ');
+
+  if (!isActive) return null;
+
+  return (
+    <div className={classNames} role="tabpanel" {...props}>
+      {children}
+    </div>
+  );
+}
+
+export default Tabs;

--- a/src/components/ui/__stories__/Menu.stories.tsx
+++ b/src/components/ui/__stories__/Menu.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Menu, MenuButton, MenuList, MenuItem, MenuDivider } from '../Menu';
+import { Button } from '../';
+
+const meta: Meta<typeof Menu> = {
+  title: 'Navigation/Menu',
+  component: Menu,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Menu>;
+
+export const Default: Story = {
+  render: () => (
+    <Menu>
+      <MenuButton>
+        <Button variant="outline">Menu</Button>
+      </MenuButton>
+      <MenuList>
+        <MenuItem>Edit</MenuItem>
+        <MenuItem>Duplicate</MenuItem>
+        <MenuDivider />
+        <MenuItem>Delete</MenuItem>
+      </MenuList>
+    </Menu>
+  ),
+};
+
+export const WithIcons: Story = {
+  render: () => (
+    <Menu>
+      <MenuButton>
+        <Button variant="outline">Actions</Button>
+      </MenuButton>
+      <MenuList>
+        <MenuItem
+          icon={
+            <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor">
+              <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z" />
+            </svg>
+          }
+        >
+          Edit
+        </MenuItem>
+        <MenuItem
+          icon={
+            <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor">
+              <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z" />
+            </svg>
+          }
+        >
+          Duplicate
+        </MenuItem>
+        <MenuDivider />
+        <MenuItem
+          icon={
+            <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor">
+              <path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z" />
+            </svg>
+          }
+        >
+          Delete
+        </MenuItem>
+      </MenuList>
+    </Menu>
+  ),
+};

--- a/src/components/ui/__stories__/Tabs.stories.tsx
+++ b/src/components/ui/__stories__/Tabs.stories.tsx
@@ -1,0 +1,130 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Tabs, TabList, Tab, TabPanels, TabPanel } from '../Tabs';
+import { Text, VStack } from '../';
+
+const meta: Meta<typeof Tabs> = {
+  title: 'Navigation/Tabs',
+  component: Tabs,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Tabs>;
+
+export const Default: Story = {
+  render: () => (
+    <Tabs>
+      <TabList>
+        <Tab>Tab 1</Tab>
+        <Tab>Tab 2</Tab>
+        <Tab>Tab 3</Tab>
+      </TabList>
+      <TabPanels>
+        <TabPanel>
+          <Text>Content for Tab 1</Text>
+        </TabPanel>
+        <TabPanel>
+          <Text>Content for Tab 2</Text>
+        </TabPanel>
+        <TabPanel>
+          <Text>Content for Tab 3</Text>
+        </TabPanel>
+      </TabPanels>
+    </Tabs>
+  ),
+};
+
+export const Variants: Story = {
+  render: () => (
+    <VStack spacing={8} align="stretch">
+      <div>
+        <Text style={{ marginBottom: '8px', fontWeight: 600 }}>Line (Default)</Text>
+        <Tabs variant="line">
+          <TabList>
+            <Tab>Tab 1</Tab>
+            <Tab>Tab 2</Tab>
+            <Tab>Tab 3</Tab>
+          </TabList>
+          <TabPanels>
+            <TabPanel>
+              <Text>Line variant content</Text>
+            </TabPanel>
+            <TabPanel>
+              <Text>Content 2</Text>
+            </TabPanel>
+            <TabPanel>
+              <Text>Content 3</Text>
+            </TabPanel>
+          </TabPanels>
+        </Tabs>
+      </div>
+
+      <div>
+        <Text style={{ marginBottom: '8px', fontWeight: 600 }}>Enclosed</Text>
+        <Tabs variant="enclosed">
+          <TabList>
+            <Tab>Tab 1</Tab>
+            <Tab>Tab 2</Tab>
+            <Tab>Tab 3</Tab>
+          </TabList>
+          <TabPanels>
+            <TabPanel>
+              <Text>Enclosed variant content</Text>
+            </TabPanel>
+            <TabPanel>
+              <Text>Content 2</Text>
+            </TabPanel>
+            <TabPanel>
+              <Text>Content 3</Text>
+            </TabPanel>
+          </TabPanels>
+        </Tabs>
+      </div>
+
+      <div>
+        <Text style={{ marginBottom: '8px', fontWeight: 600 }}>Soft Rounded</Text>
+        <Tabs variant="soft-rounded">
+          <TabList>
+            <Tab>Tab 1</Tab>
+            <Tab>Tab 2</Tab>
+            <Tab>Tab 3</Tab>
+          </TabList>
+          <TabPanels>
+            <TabPanel>
+              <Text>Soft rounded variant content</Text>
+            </TabPanel>
+            <TabPanel>
+              <Text>Content 2</Text>
+            </TabPanel>
+            <TabPanel>
+              <Text>Content 3</Text>
+            </TabPanel>
+          </TabPanels>
+        </Tabs>
+      </div>
+    </VStack>
+  ),
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <Tabs>
+      <TabList>
+        <Tab>Tab 1</Tab>
+        <Tab isDisabled>Disabled</Tab>
+        <Tab>Tab 3</Tab>
+      </TabList>
+      <TabPanels>
+        <TabPanel>
+          <Text>Content for Tab 1</Text>
+        </TabPanel>
+        <TabPanel>
+          <Text>Content for disabled tab (not visible)</Text>
+        </TabPanel>
+        <TabPanel>
+          <Text>Content for Tab 3</Text>
+        </TabPanel>
+      </TabPanels>
+    </Tabs>
+  ),
+};

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -24,6 +24,8 @@ export { Spinner } from './Spinner';
 export { Divider } from './Divider';
 export { Modal, ModalHeader, ModalBody, ModalFooter, ModalCloseButton } from './Modal';
 export { Tooltip } from './Tooltip';
+export { Menu, MenuButton, MenuList, MenuItem, MenuDivider } from './Menu';
+export { Tabs, TabList, Tab, TabPanels, TabPanel } from './Tabs';
 
 export { default as ProgressBar } from './ProgressBar';
 export { default as EmptyState } from './EmptyState';
@@ -59,3 +61,5 @@ export type { SpinnerProps, SpinnerSize } from './Spinner';
 export type { DividerProps, DividerOrientation } from './Divider';
 export type { ModalProps, ModalSize, ModalHeaderProps, ModalBodyProps, ModalFooterProps, ModalCloseButtonProps } from './Modal';
 export type { TooltipProps, TooltipPlacement } from './Tooltip';
+export type { MenuProps, MenuButtonProps, MenuListProps, MenuItemProps, MenuDividerProps } from './Menu';
+export type { TabsProps, TabsVariant, TabListProps, TabProps, TabPanelsProps, TabPanelProps } from './Tabs';


### PR DESCRIPTION
## Summary
- Menu コンポーネント (Portal使用、ESCキー/外部クリックで閉じる)
- Tabs コンポーネント (line/enclosed/soft-rounded variants、制御/非制御モード)
- Storybookストーリー追加

## Test plan
- [ ] `npm run build` でビルド成功を確認
- [ ] Storybookで各コンポーネントの表示確認

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)