### PR TITLE
FormコンポーネントのCSS Modules移行

### DIFF
--- a/src/components/form/FormCheckbox.tsx
+++ b/src/components/form/FormCheckbox.tsx
@@ -1,48 +1,47 @@
-import {
-  FormControl,
-  FormErrorMessage,
-  Checkbox,
-  CheckboxProps,
-  Box,
-} from '@chakra-ui/react';
-import { forwardRef } from 'react';
+import { forwardRef, InputHTMLAttributes, ReactNode } from 'react';
 import { motion } from 'framer-motion';
+import styles from '../../styles/components/form.module.css';
 
-const MotionBox = motion(Box);
-
-interface FormCheckboxProps extends CheckboxProps {
+interface FormCheckboxProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type'> {
   error?: string;
   isAnimated?: boolean;
+  children?: ReactNode;
 }
 
 const FormCheckbox = forwardRef<HTMLInputElement, FormCheckboxProps>(
-  ({ error, isAnimated = true, children, ...props }, ref) => {
+  ({ error, isAnimated = true, children, className, ...props }, ref) => {
     const checkbox = (
-      <Checkbox ref={ref} colorScheme="primary" {...props}>
-        {children}
-      </Checkbox>
+      <label className={styles.checkbox}>
+        <input
+          ref={ref}
+          type="checkbox"
+          className={styles.checkboxInput}
+          {...props}
+        />
+        {children && <span className={styles.checkboxLabel}>{children}</span>}
+      </label>
     );
 
     if (isAnimated) {
       return (
-        <FormControl isInvalid={!!error}>
-          <MotionBox
-            display="inline-block"
+        <div className={styles.formControl}>
+          <motion.div
+            style={{ display: 'inline-block' }}
             whileHover={{ scale: 1.05 }}
             whileTap={{ scale: 0.95 }}
           >
             {checkbox}
-          </MotionBox>
-          {error && <FormErrorMessage>{error}</FormErrorMessage>}
-        </FormControl>
+          </motion.div>
+          {error && <p className={styles.errorMessage}>{error}</p>}
+        </div>
       );
     }
 
     return (
-      <FormControl isInvalid={!!error}>
+      <div className={styles.formControl}>
         {checkbox}
-        {error && <FormErrorMessage>{error}</FormErrorMessage>}
-      </FormControl>
+        {error && <p className={styles.errorMessage}>{error}</p>}
+      </div>
     );
   }
 );

--- a/src/components/form/FormInput.tsx
+++ b/src/components/form/FormInput.tsx
@@ -1,17 +1,7 @@
-import {
-  FormControl,
-  FormLabel,
-  FormErrorMessage,
-  FormHelperText,
-  Input,
-  InputProps,
-  InputGroup,
-  InputLeftElement,
-  InputRightElement,
-} from '@chakra-ui/react';
-import { forwardRef, ReactNode } from 'react';
+import { forwardRef, InputHTMLAttributes, ReactNode } from 'react';
+import styles from '../../styles/components/form.module.css';
 
-interface FormInputProps extends InputProps {
+interface FormInputProps extends InputHTMLAttributes<HTMLInputElement> {
   label?: string;
   error?: string;
   helperText?: string;
@@ -29,6 +19,7 @@ const FormInput = forwardRef<HTMLInputElement, FormInputProps>(
       isRequired = false,
       leftElement,
       rightElement,
+      className,
       ...props
     },
     ref
@@ -36,23 +27,26 @@ const FormInput = forwardRef<HTMLInputElement, FormInputProps>(
     const hasLeftElement = !!leftElement;
     const hasRightElement = !!rightElement;
 
+    const labelClasses = [styles.label, isRequired ? styles.labelRequired : ''].filter(Boolean).join(' ');
+    const inputClasses = [
+      styles.input,
+      error ? styles.inputError : '',
+      hasLeftElement ? styles.inputWithLeftElement : '',
+      hasRightElement ? styles.inputWithRightElement : '',
+      className,
+    ].filter(Boolean).join(' ');
+
     return (
-      <FormControl isInvalid={!!error} isRequired={isRequired}>
-        {label && <FormLabel>{label}</FormLabel>}
-        {hasLeftElement || hasRightElement ? (
-          <InputGroup>
-            {hasLeftElement && (
-              <InputLeftElement pointerEvents="none">{leftElement}</InputLeftElement>
-            )}
-            <Input ref={ref} bg="white" {...props} />
-            {hasRightElement && <InputRightElement>{rightElement}</InputRightElement>}
-          </InputGroup>
-        ) : (
-          <Input ref={ref} bg="white" {...props} />
-        )}
-        {error && <FormErrorMessage>{error}</FormErrorMessage>}
-        {helperText && !error && <FormHelperText>{helperText}</FormHelperText>}
-      </FormControl>
+      <div className={styles.formControl}>
+        {label && <label className={labelClasses}>{label}</label>}
+        <div className={styles.inputGroup}>
+          {hasLeftElement && <span className={styles.leftElement}>{leftElement}</span>}
+          <input ref={ref} className={inputClasses} {...props} />
+          {hasRightElement && <span className={styles.rightElement}>{rightElement}</span>}
+        </div>
+        {error && <p className={styles.errorMessage}>{error}</p>}
+        {helperText && !error && <p className={styles.helperText}>{helperText}</p>}
+      </div>
     );
   }
 );

--- a/src/components/form/FormRadioGroup.tsx
+++ b/src/components/form/FormRadioGroup.tsx
@@ -1,47 +1,53 @@
-import {
-  FormControl,
-  FormLabel,
-  FormErrorMessage,
-  RadioGroup,
-  Radio,
-  Stack,
-  RadioGroupProps,
-} from '@chakra-ui/react';
+import styles from '../../styles/components/form.module.css';
 
 interface RadioOption {
   value: string;
   label: string;
 }
 
-interface FormRadioGroupProps extends Omit<RadioGroupProps, 'children'> {
+interface FormRadioGroupProps {
+  name: string;
   label?: string;
   error?: string;
   isRequired?: boolean;
   options: RadioOption[];
   direction?: 'row' | 'column';
+  value?: string;
+  onChange?: (value: string) => void;
 }
 
 export default function FormRadioGroup({
+  name,
   label,
   error,
   isRequired = false,
   options,
   direction = 'row',
-  ...props
+  value,
+  onChange,
 }: FormRadioGroupProps) {
+  const labelClasses = [styles.label, isRequired ? styles.labelRequired : ''].filter(Boolean).join(' ');
+  const radioGroupClasses = [styles.radioGroup, direction === 'column' ? styles.radioGroupColumn : ''].filter(Boolean).join(' ');
+
   return (
-    <FormControl isInvalid={!!error} isRequired={isRequired}>
-      {label && <FormLabel>{label}</FormLabel>}
-      <RadioGroup {...props}>
-        <Stack direction={direction} spacing={4}>
-          {options.map((option) => (
-            <Radio key={option.value} value={option.value} colorScheme="primary">
-              {option.label}
-            </Radio>
-          ))}
-        </Stack>
-      </RadioGroup>
-      {error && <FormErrorMessage>{error}</FormErrorMessage>}
-    </FormControl>
+    <div className={styles.formControl}>
+      {label && <label className={labelClasses}>{label}</label>}
+      <div className={radioGroupClasses}>
+        {options.map((option) => (
+          <label key={option.value} className={styles.radio}>
+            <input
+              type="radio"
+              name={name}
+              value={option.value}
+              checked={value === option.value}
+              onChange={(e) => onChange?.(e.target.value)}
+              className={styles.radioInput}
+            />
+            <span className={styles.radioLabel}>{option.label}</span>
+          </label>
+        ))}
+      </div>
+      {error && <p className={styles.errorMessage}>{error}</p>}
+    </div>
   );
 }

--- a/src/components/form/FormSelect.tsx
+++ b/src/components/form/FormSelect.tsx
@@ -1,19 +1,12 @@
-import {
-  FormControl,
-  FormLabel,
-  FormErrorMessage,
-  FormHelperText,
-  Select,
-  SelectProps,
-} from '@chakra-ui/react';
-import { forwardRef } from 'react';
+import { forwardRef, SelectHTMLAttributes } from 'react';
+import styles from '../../styles/components/form.module.css';
 
 interface SelectOption {
   value: string;
   label: string;
 }
 
-interface FormSelectProps extends Omit<SelectProps, 'children'> {
+interface FormSelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
   label?: string;
   error?: string;
   helperText?: string;
@@ -31,23 +24,28 @@ const FormSelect = forwardRef<HTMLSelectElement, FormSelectProps>(
       isRequired = false,
       options,
       placeholder = '選択してください',
+      className,
       ...props
     },
     ref
   ) => {
+    const labelClasses = [styles.label, isRequired ? styles.labelRequired : ''].filter(Boolean).join(' ');
+    const selectClasses = [styles.select, error ? styles.inputError : '', className].filter(Boolean).join(' ');
+
     return (
-      <FormControl isInvalid={!!error} isRequired={isRequired}>
-        {label && <FormLabel>{label}</FormLabel>}
-        <Select ref={ref} bg="white" placeholder={placeholder} {...props}>
+      <div className={styles.formControl}>
+        {label && <label className={labelClasses}>{label}</label>}
+        <select ref={ref} className={selectClasses} {...props}>
+          <option value="">{placeholder}</option>
           {options.map((option) => (
             <option key={option.value} value={option.value}>
               {option.label}
             </option>
           ))}
-        </Select>
-        {error && <FormErrorMessage>{error}</FormErrorMessage>}
-        {helperText && !error && <FormHelperText>{helperText}</FormHelperText>}
-      </FormControl>
+        </select>
+        {error && <p className={styles.errorMessage}>{error}</p>}
+        {helperText && !error && <p className={styles.helperText}>{helperText}</p>}
+      </div>
     );
   }
 );

--- a/src/components/form/FormTextarea.tsx
+++ b/src/components/form/FormTextarea.tsx
@@ -1,14 +1,7 @@
-import {
-  FormControl,
-  FormLabel,
-  FormErrorMessage,
-  FormHelperText,
-  Textarea,
-  TextareaProps,
-} from '@chakra-ui/react';
-import { forwardRef } from 'react';
+import { forwardRef, TextareaHTMLAttributes } from 'react';
+import styles from '../../styles/components/form.module.css';
 
-interface FormTextareaProps extends TextareaProps {
+interface FormTextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
   label?: string;
   error?: string;
   helperText?: string;
@@ -16,14 +9,17 @@ interface FormTextareaProps extends TextareaProps {
 }
 
 const FormTextarea = forwardRef<HTMLTextAreaElement, FormTextareaProps>(
-  ({ label, error, helperText, isRequired = false, ...props }, ref) => {
+  ({ label, error, helperText, isRequired = false, className, ...props }, ref) => {
+    const labelClasses = [styles.label, isRequired ? styles.labelRequired : ''].filter(Boolean).join(' ');
+    const textareaClasses = [styles.textarea, error ? styles.inputError : '', className].filter(Boolean).join(' ');
+
     return (
-      <FormControl isInvalid={!!error} isRequired={isRequired}>
-        {label && <FormLabel>{label}</FormLabel>}
-        <Textarea ref={ref} bg="white" {...props} />
-        {error && <FormErrorMessage>{error}</FormErrorMessage>}
-        {helperText && !error && <FormHelperText>{helperText}</FormHelperText>}
-      </FormControl>
+      <div className={styles.formControl}>
+        {label && <label className={labelClasses}>{label}</label>}
+        <textarea ref={ref} className={textareaClasses} {...props} />
+        {error && <p className={styles.errorMessage}>{error}</p>}
+        {helperText && !error && <p className={styles.helperText}>{helperText}</p>}
+      </div>
     );
   }
 );

--- a/src/components/form/SearchInput.tsx
+++ b/src/components/form/SearchInput.tsx
@@ -1,14 +1,8 @@
-import {
-  Input,
-  InputGroup,
-  InputLeftElement,
-  InputRightElement,
-  IconButton,
-  InputProps,
-} from '@chakra-ui/react';
+import { InputHTMLAttributes } from 'react';
 import { FiSearch, FiX } from 'react-icons/fi';
+import styles from '../../styles/components/form.module.css';
 
-interface SearchInputProps extends Omit<InputProps, 'onChange'> {
+interface SearchInputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'onChange'> {
   value: string;
   onChange: (value: string) => void;
   onClear?: () => void;
@@ -21,6 +15,7 @@ export default function SearchInput({
   onClear,
   showClearButton = true,
   placeholder = '検索...',
+  className,
   ...props
 }: SearchInputProps) {
   const handleClear = () => {
@@ -28,29 +23,32 @@ export default function SearchInput({
     onClear?.();
   };
 
+  const inputClasses = [styles.input, styles.inputWithLeftElement, value && showClearButton ? styles.inputWithRightElement : '', className].filter(Boolean).join(' ');
+
   return (
-    <InputGroup>
-      <InputLeftElement pointerEvents="none">
-        <FiSearch color="gray" />
-      </InputLeftElement>
-      <Input
+    <div className={styles.inputGroup}>
+      <span className={styles.leftElement}>
+        <FiSearch />
+      </span>
+      <input
         placeholder={placeholder}
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        bg="white"
+        className={inputClasses}
         {...props}
       />
       {showClearButton && value && (
-        <InputRightElement>
-          <IconButton
-            aria-label="クリア"
-            icon={<FiX />}
-            size="sm"
-            variant="ghost"
+        <span className={styles.rightElement}>
+          <button
+            type="button"
+            className={styles.clearButton}
             onClick={handleClear}
-          />
-        </InputRightElement>
+            aria-label="クリア"
+          >
+            <FiX />
+          </button>
+        </span>
       )}
-    </InputGroup>
+    </div>
   );
 }

--- a/src/styles/components/form.module.css
+++ b/src/styles/components/form.module.css
@@ -1,0 +1,184 @@
+.formControl {
+  margin-bottom: var(--spacing-4);
+}
+
+.label {
+  display: block;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-gray-700);
+  margin-bottom: var(--spacing-1);
+}
+
+.labelRequired::after {
+  content: ' *';
+  color: var(--color-red-500);
+}
+
+.input {
+  width: 100%;
+  padding: var(--spacing-2) var(--spacing-3);
+  font-size: var(--font-size-sm);
+  border: 1px solid var(--color-gray-300);
+  border-radius: var(--radius-md);
+  background-color: white;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.input:focus {
+  outline: none;
+  border-color: var(--color-blue-500);
+  box-shadow: 0 0 0 1px var(--color-blue-500);
+}
+
+.input:disabled {
+  background-color: var(--color-gray-100);
+  cursor: not-allowed;
+}
+
+.inputError {
+  border-color: var(--color-red-500);
+}
+
+.inputError:focus {
+  border-color: var(--color-red-500);
+  box-shadow: 0 0 0 1px var(--color-red-500);
+}
+
+.inputGroup {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.inputWithLeftElement {
+  padding-left: var(--spacing-10);
+}
+
+.inputWithRightElement {
+  padding-right: var(--spacing-10);
+}
+
+.leftElement {
+  position: absolute;
+  left: var(--spacing-3);
+  display: flex;
+  align-items: center;
+  pointer-events: none;
+  color: var(--color-gray-400);
+}
+
+.rightElement {
+  position: absolute;
+  right: var(--spacing-2);
+  display: flex;
+  align-items: center;
+}
+
+.select {
+  width: 100%;
+  padding: var(--spacing-2) var(--spacing-3);
+  font-size: var(--font-size-sm);
+  border: 1px solid var(--color-gray-300);
+  border-radius: var(--radius-md);
+  background-color: white;
+  cursor: pointer;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.select:focus {
+  outline: none;
+  border-color: var(--color-blue-500);
+  box-shadow: 0 0 0 1px var(--color-blue-500);
+}
+
+.textarea {
+  width: 100%;
+  padding: var(--spacing-2) var(--spacing-3);
+  font-size: var(--font-size-sm);
+  border: 1px solid var(--color-gray-300);
+  border-radius: var(--radius-md);
+  background-color: white;
+  resize: vertical;
+  min-height: 100px;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.textarea:focus {
+  outline: none;
+  border-color: var(--color-blue-500);
+  box-shadow: 0 0 0 1px var(--color-blue-500);
+}
+
+.errorMessage {
+  font-size: var(--font-size-sm);
+  color: var(--color-red-500);
+  margin-top: var(--spacing-1);
+}
+
+.helperText {
+  font-size: var(--font-size-sm);
+  color: var(--color-gray-500);
+  margin-top: var(--spacing-1);
+}
+
+.checkbox {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  cursor: pointer;
+}
+
+.checkboxInput {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--color-blue-500);
+  cursor: pointer;
+}
+
+.checkboxLabel {
+  font-size: var(--font-size-sm);
+  color: var(--color-gray-700);
+}
+
+.radioGroup {
+  display: flex;
+  gap: var(--spacing-4);
+}
+
+.radioGroupColumn {
+  flex-direction: column;
+}
+
+.radio {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  cursor: pointer;
+}
+
+.radioInput {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--color-blue-500);
+  cursor: pointer;
+}
+
+.radioLabel {
+  font-size: var(--font-size-sm);
+  color: var(--color-gray-700);
+}
+
+.clearButton {
+  padding: var(--spacing-1);
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-gray-400);
+  border-radius: var(--radius-sm);
+  transition: color var(--transition-fast);
+}
+
+.clearButton:hover {
+  color: var(--color-gray-600);
+}


### PR DESCRIPTION
## Summary
- FormコンポーネントをChakra UIからCSS Modulesに移行
- FormInput, FormSelect, FormTextarea, FormCheckbox, FormRadioGroup, SearchInputを移行

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)