### PR TITLE
feat: Table、Stat、ProgressコンポーネントをCSS Modulesで実装 (#118)

### DIFF
--- a/src/components/ui/Progress.module.css
+++ b/src/components/ui/Progress.module.css
@@ -1,0 +1,138 @@
+.progress {
+  width: 100%;
+  background-color: var(--color-gray-200);
+  border-radius: var(--radius-full);
+  overflow: hidden;
+}
+
+/* Sizes */
+.xs {
+  height: 4px;
+}
+
+.sm {
+  height: 6px;
+}
+
+.md {
+  height: 8px;
+}
+
+.lg {
+  height: 12px;
+}
+
+.progressBar {
+  height: 100%;
+  border-radius: var(--radius-full);
+  transition: width 0.3s ease;
+}
+
+/* Color schemes */
+.progressBar.primary {
+  background-color: var(--color-primary-500);
+}
+
+.progressBar.green {
+  background-color: var(--color-green-500);
+}
+
+.progressBar.blue {
+  background-color: var(--color-blue-500);
+}
+
+.progressBar.red {
+  background-color: var(--color-red-500);
+}
+
+.progressBar.yellow {
+  background-color: var(--color-yellow-500);
+}
+
+.progressBar.gray {
+  background-color: var(--color-gray-500);
+}
+
+/* Striped */
+.striped {
+  background-image: linear-gradient(
+    45deg,
+    rgba(255, 255, 255, 0.15) 25%,
+    transparent 25%,
+    transparent 50%,
+    rgba(255, 255, 255, 0.15) 50%,
+    rgba(255, 255, 255, 0.15) 75%,
+    transparent 75%,
+    transparent
+  );
+  background-size: 1rem 1rem;
+}
+
+.animated {
+  animation: stripeMove 1s linear infinite;
+}
+
+@keyframes stripeMove {
+  from {
+    background-position: 1rem 0;
+  }
+  to {
+    background-position: 0 0;
+  }
+}
+
+/* Indeterminate */
+.indeterminate {
+  width: 30%;
+  animation: indeterminate 1.5s ease-in-out infinite;
+}
+
+@keyframes indeterminate {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(400%);
+  }
+}
+
+/* Label */
+.progressLabel {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: var(--font-size-xs);
+  margin-bottom: var(--spacing-1);
+}
+
+.progressLabelText {
+  color: var(--color-gray-500);
+}
+
+.progressLabelValue {
+  font-weight: var(--font-weight-semibold);
+}
+
+.progressLabelValue.primary {
+  color: var(--color-primary-600);
+}
+
+.progressLabelValue.green {
+  color: var(--color-green-600);
+}
+
+.progressLabelValue.blue {
+  color: var(--color-blue-600);
+}
+
+.progressLabelValue.red {
+  color: var(--color-red-600);
+}
+
+.progressLabelValue.yellow {
+  color: var(--color-yellow-600);
+}
+
+.progressLabelValue.gray {
+  color: var(--color-gray-600);
+}

--- a/src/components/ui/Progress.tsx
+++ b/src/components/ui/Progress.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import styles from './Progress.module.css';
+
+export type ProgressSize = 'xs' | 'sm' | 'md' | 'lg';
+export type ProgressColorScheme = 'primary' | 'green' | 'blue' | 'red' | 'yellow' | 'gray';
+
+export interface ProgressProps extends React.HTMLAttributes<HTMLDivElement> {
+  value: number;
+  size?: ProgressSize;
+  colorScheme?: ProgressColorScheme;
+  hasStripe?: boolean;
+  isAnimated?: boolean;
+  isIndeterminate?: boolean;
+}
+
+export function Progress({
+  value,
+  size = 'md',
+  colorScheme = 'primary',
+  hasStripe = false,
+  isAnimated = false,
+  isIndeterminate = false,
+  className,
+  ...props
+}: ProgressProps) {
+  const clampedValue = Math.min(100, Math.max(0, value));
+
+  const containerClassNames = [styles.progress, styles[size], className]
+    .filter(Boolean)
+    .join(' ');
+
+  const barClassNames = [
+    styles.progressBar,
+    styles[colorScheme],
+    hasStripe ? styles.striped : '',
+    isAnimated ? styles.animated : '',
+    isIndeterminate ? styles.indeterminate : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div
+      className={containerClassNames}
+      role="progressbar"
+      aria-valuenow={isIndeterminate ? undefined : clampedValue}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      {...props}
+    >
+      <div
+        className={barClassNames}
+        style={isIndeterminate ? undefined : { width: `${clampedValue}%` }}
+      />
+    </div>
+  );
+}
+
+export interface ProgressLabelProps extends React.HTMLAttributes<HTMLDivElement> {
+  value: number;
+  colorScheme?: ProgressColorScheme;
+}
+
+export function ProgressLabel({
+  value,
+  colorScheme = 'primary',
+  className,
+  ...props
+}: ProgressLabelProps) {
+  const classNames = [styles.progressLabel, className].filter(Boolean).join(' ');
+  const clampedValue = Math.min(100, Math.max(0, value));
+
+  return (
+    <div className={classNames} {...props}>
+      <span className={styles.progressLabelText}>進捗率</span>
+      <span className={`${styles.progressLabelValue} ${styles[colorScheme]}`}>
+        {clampedValue}%
+      </span>
+    </div>
+  );
+}
+
+export default Progress;

--- a/src/components/ui/Stat.module.css
+++ b/src/components/ui/Stat.module.css
@@ -1,0 +1,39 @@
+.stat {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.statLabel {
+  font-size: var(--font-size-sm);
+  color: var(--color-gray-500);
+  font-weight: var(--font-weight-medium);
+}
+
+.statNumber {
+  font-size: var(--font-size-3xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-gray-900);
+  line-height: 1.2;
+}
+
+.statHelpText {
+  font-size: var(--font-size-sm);
+  color: var(--color-gray-500);
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-1);
+}
+
+.statArrow {
+  display: inline-flex;
+  align-items: center;
+}
+
+.statArrow.increase {
+  color: var(--color-green-500);
+}
+
+.statArrow.decrease {
+  color: var(--color-red-500);
+}

--- a/src/components/ui/Stat.tsx
+++ b/src/components/ui/Stat.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import styles from './Stat.module.css';
+
+export interface StatProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function Stat({ className, children, ...props }: StatProps) {
+  const classNames = [styles.stat, className].filter(Boolean).join(' ');
+  return (
+    <div className={classNames} {...props}>
+      {children}
+    </div>
+  );
+}
+
+export interface StatLabelProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function StatLabel({ className, children, ...props }: StatLabelProps) {
+  const classNames = [styles.statLabel, className].filter(Boolean).join(' ');
+  return (
+    <div className={classNames} {...props}>
+      {children}
+    </div>
+  );
+}
+
+export interface StatNumberProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function StatNumber({ className, children, ...props }: StatNumberProps) {
+  const classNames = [styles.statNumber, className].filter(Boolean).join(' ');
+  return (
+    <div className={classNames} {...props}>
+      {children}
+    </div>
+  );
+}
+
+export interface StatHelpTextProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function StatHelpText({ className, children, ...props }: StatHelpTextProps) {
+  const classNames = [styles.statHelpText, className].filter(Boolean).join(' ');
+  return (
+    <div className={classNames} {...props}>
+      {children}
+    </div>
+  );
+}
+
+export type StatArrowType = 'increase' | 'decrease';
+
+export interface StatArrowProps extends React.HTMLAttributes<HTMLSpanElement> {
+  type: StatArrowType;
+}
+
+export function StatArrow({ type, className, ...props }: StatArrowProps) {
+  const classNames = [styles.statArrow, styles[type], className].filter(Boolean).join(' ');
+
+  return (
+    <span className={classNames} aria-label={type === 'increase' ? '増加' : '減少'} {...props}>
+      {type === 'increase' ? (
+        <svg viewBox="0 0 24 24" fill="currentColor" width="14" height="14">
+          <path d="M7 14l5-5 5 5z" />
+        </svg>
+      ) : (
+        <svg viewBox="0 0 24 24" fill="currentColor" width="14" height="14">
+          <path d="M7 10l5 5 5-5z" />
+        </svg>
+      )}
+    </span>
+  );
+}
+
+export default Stat;

--- a/src/components/ui/Table.module.css
+++ b/src/components/ui/Table.module.css
@@ -1,0 +1,74 @@
+.tableContainer {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.thead {
+  border-bottom: 1px solid var(--color-gray-200);
+}
+
+.tbody .tr {
+  border-bottom: 1px solid var(--color-gray-100);
+}
+
+.tbody .tr:last-child {
+  border-bottom: none;
+}
+
+.th,
+.td {
+  text-align: left;
+  vertical-align: middle;
+}
+
+.th {
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-gray-600);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.td {
+  color: var(--color-gray-700);
+}
+
+.numeric {
+  text-align: right;
+}
+
+/* Sizes */
+.sm .th,
+.sm .td {
+  padding: var(--spacing-2) var(--spacing-3);
+  font-size: var(--font-size-xs);
+}
+
+.md .th,
+.md .td {
+  padding: var(--spacing-3) var(--spacing-4);
+  font-size: var(--font-size-sm);
+}
+
+.lg .th,
+.lg .td {
+  padding: var(--spacing-4) var(--spacing-6);
+  font-size: var(--font-size-md);
+}
+
+/* Variants */
+.striped .tbody .tr:nth-child(odd) {
+  background-color: var(--color-gray-50);
+}
+
+.simple .tbody .tr:hover {
+  background-color: var(--color-gray-50);
+}
+
+.striped .tbody .tr:hover {
+  background-color: var(--color-gray-100);
+}

--- a/src/components/ui/Table.tsx
+++ b/src/components/ui/Table.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import styles from './Table.module.css';
+
+export type TableSize = 'sm' | 'md' | 'lg';
+export type TableVariant = 'simple' | 'striped';
+
+export interface TableProps extends React.TableHTMLAttributes<HTMLTableElement> {
+  size?: TableSize;
+  variant?: TableVariant;
+}
+
+export function Table({
+  size = 'md',
+  variant = 'simple',
+  className,
+  children,
+  ...props
+}: TableProps) {
+  const classNames = [styles.table, styles[size], styles[variant], className]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div className={styles.tableContainer}>
+      <table className={classNames} {...props}>
+        {children}
+      </table>
+    </div>
+  );
+}
+
+export interface TheadProps extends React.HTMLAttributes<HTMLTableSectionElement> {}
+
+export function Thead({ className, children, ...props }: TheadProps) {
+  const classNames = [styles.thead, className].filter(Boolean).join(' ');
+  return (
+    <thead className={classNames} {...props}>
+      {children}
+    </thead>
+  );
+}
+
+export interface TbodyProps extends React.HTMLAttributes<HTMLTableSectionElement> {}
+
+export function Tbody({ className, children, ...props }: TbodyProps) {
+  const classNames = [styles.tbody, className].filter(Boolean).join(' ');
+  return (
+    <tbody className={classNames} {...props}>
+      {children}
+    </tbody>
+  );
+}
+
+export interface TrProps extends React.HTMLAttributes<HTMLTableRowElement> {}
+
+export function Tr({ className, children, ...props }: TrProps) {
+  const classNames = [styles.tr, className].filter(Boolean).join(' ');
+  return (
+    <tr className={classNames} {...props}>
+      {children}
+    </tr>
+  );
+}
+
+export interface ThProps extends React.ThHTMLAttributes<HTMLTableCellElement> {
+  isNumeric?: boolean;
+}
+
+export function Th({ isNumeric = false, className, children, ...props }: ThProps) {
+  const classNames = [styles.th, isNumeric ? styles.numeric : '', className]
+    .filter(Boolean)
+    .join(' ');
+  return (
+    <th className={classNames} {...props}>
+      {children}
+    </th>
+  );
+}
+
+export interface TdProps extends React.TdHTMLAttributes<HTMLTableCellElement> {
+  isNumeric?: boolean;
+}
+
+export function Td({ isNumeric = false, className, children, ...props }: TdProps) {
+  const classNames = [styles.td, isNumeric ? styles.numeric : '', className]
+    .filter(Boolean)
+    .join(' ');
+  return (
+    <td className={classNames} {...props}>
+      {children}
+    </td>
+  );
+}
+
+export default Table;

--- a/src/components/ui/__stories__/Progress.stories.tsx
+++ b/src/components/ui/__stories__/Progress.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Progress, ProgressLabel } from '../Progress';
+import { VStack, Box } from '../';
+
+const meta: Meta<typeof Progress> = {
+  title: 'Data/Progress',
+  component: Progress,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Progress>;
+
+export const Default: Story = {
+  args: {
+    value: 60,
+  },
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <VStack spacing={4} align="stretch" style={{ width: '300px' }}>
+      <Progress value={60} size="xs" />
+      <Progress value={60} size="sm" />
+      <Progress value={60} size="md" />
+      <Progress value={60} size="lg" />
+    </VStack>
+  ),
+};
+
+export const ColorSchemes: Story = {
+  render: () => (
+    <VStack spacing={4} align="stretch" style={{ width: '300px' }}>
+      <Progress value={60} colorScheme="primary" />
+      <Progress value={60} colorScheme="green" />
+      <Progress value={60} colorScheme="blue" />
+      <Progress value={60} colorScheme="red" />
+      <Progress value={60} colorScheme="yellow" />
+    </VStack>
+  ),
+};
+
+export const Striped: Story = {
+  render: () => (
+    <VStack spacing={4} align="stretch" style={{ width: '300px' }}>
+      <Progress value={60} hasStripe />
+      <Progress value={60} hasStripe isAnimated />
+    </VStack>
+  ),
+};
+
+export const Indeterminate: Story = {
+  args: {
+    value: 0,
+    isIndeterminate: true,
+  },
+  decorators: [
+    (Story) => (
+      <Box style={{ width: '300px' }}>
+        <Story />
+      </Box>
+    ),
+  ],
+};
+
+export const WithLabel: Story = {
+  render: () => (
+    <Box style={{ width: '300px' }}>
+      <ProgressLabel value={75} colorScheme="primary" />
+      <Progress value={75} colorScheme="primary" />
+    </Box>
+  ),
+};

--- a/src/components/ui/__stories__/Stat.stories.tsx
+++ b/src/components/ui/__stories__/Stat.stories.tsx
@@ -1,0 +1,85 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Stat, StatLabel, StatNumber, StatHelpText, StatArrow } from '../Stat';
+import { HStack, Card, CardBody, SimpleGrid } from '../';
+
+const meta: Meta<typeof Stat> = {
+  title: 'Data/Stat',
+  component: Stat,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Stat>;
+
+export const Default: Story = {
+  render: () => (
+    <Stat>
+      <StatLabel>総売上</StatLabel>
+      <StatNumber>¥345,670</StatNumber>
+      <StatHelpText>1月1日 - 1月31日</StatHelpText>
+    </Stat>
+  ),
+};
+
+export const WithArrow: Story = {
+  render: () => (
+    <HStack spacing={8}>
+      <Stat>
+        <StatLabel>売上</StatLabel>
+        <StatNumber>¥345,670</StatNumber>
+        <StatHelpText>
+          <StatArrow type="increase" />
+          23.36%
+        </StatHelpText>
+      </Stat>
+      <Stat>
+        <StatLabel>コスト</StatLabel>
+        <StatNumber>¥45,670</StatNumber>
+        <StatHelpText>
+          <StatArrow type="decrease" />
+          9.05%
+        </StatHelpText>
+      </Stat>
+    </HStack>
+  ),
+};
+
+export const InCards: Story = {
+  render: () => (
+    <SimpleGrid columns={3} spacing={4}>
+      <Card>
+        <CardBody>
+          <Stat>
+            <StatLabel>タスク完了数</StatLabel>
+            <StatNumber>42</StatNumber>
+            <StatHelpText>
+              <StatArrow type="increase" />
+              12%
+            </StatHelpText>
+          </Stat>
+        </CardBody>
+      </Card>
+      <Card>
+        <CardBody>
+          <Stat>
+            <StatLabel>進行中</StatLabel>
+            <StatNumber>15</StatNumber>
+            <StatHelpText>前週比</StatHelpText>
+          </Stat>
+        </CardBody>
+      </Card>
+      <Card>
+        <CardBody>
+          <Stat>
+            <StatLabel>遅延</StatLabel>
+            <StatNumber>3</StatNumber>
+            <StatHelpText>
+              <StatArrow type="decrease" />
+              5%
+            </StatHelpText>
+          </Stat>
+        </CardBody>
+      </Card>
+    </SimpleGrid>
+  ),
+};

--- a/src/components/ui/__stories__/Table.stories.tsx
+++ b/src/components/ui/__stories__/Table.stories.tsx
@@ -1,0 +1,134 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Table, Thead, Tbody, Tr, Th, Td } from '../Table';
+import { VStack, Badge } from '../';
+
+const meta: Meta<typeof Table> = {
+  title: 'Data/Table',
+  component: Table,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Table>;
+
+const sampleData = [
+  { id: 1, name: 'タスク A', status: '進行中', priority: '高', assignee: '田中' },
+  { id: 2, name: 'タスク B', status: '完了', priority: '中', assignee: '佐藤' },
+  { id: 3, name: 'タスク C', status: '未着手', priority: '低', assignee: '鈴木' },
+];
+
+export const Default: Story = {
+  render: () => (
+    <Table>
+      <Thead>
+        <Tr>
+          <Th>ID</Th>
+          <Th>タスク名</Th>
+          <Th>ステータス</Th>
+          <Th>優先度</Th>
+          <Th>担当者</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        {sampleData.map((row) => (
+          <Tr key={row.id}>
+            <Td>{row.id}</Td>
+            <Td>{row.name}</Td>
+            <Td>
+              <Badge
+                colorScheme={
+                  row.status === '完了' ? 'green' : row.status === '進行中' ? 'blue' : 'gray'
+                }
+              >
+                {row.status}
+              </Badge>
+            </Td>
+            <Td>{row.priority}</Td>
+            <Td>{row.assignee}</Td>
+          </Tr>
+        ))}
+      </Tbody>
+    </Table>
+  ),
+};
+
+export const Striped: Story = {
+  render: () => (
+    <Table variant="striped">
+      <Thead>
+        <Tr>
+          <Th>ID</Th>
+          <Th>タスク名</Th>
+          <Th>ステータス</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        {sampleData.map((row) => (
+          <Tr key={row.id}>
+            <Td>{row.id}</Td>
+            <Td>{row.name}</Td>
+            <Td>{row.status}</Td>
+          </Tr>
+        ))}
+      </Tbody>
+    </Table>
+  ),
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <VStack spacing={8} align="stretch">
+      <div>
+        <p style={{ marginBottom: '8px', fontWeight: 600 }}>Small</p>
+        <Table size="sm">
+          <Thead>
+            <Tr>
+              <Th>Name</Th>
+              <Th isNumeric>Value</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            <Tr>
+              <Td>Item A</Td>
+              <Td isNumeric>100</Td>
+            </Tr>
+          </Tbody>
+        </Table>
+      </div>
+      <div>
+        <p style={{ marginBottom: '8px', fontWeight: 600 }}>Medium (Default)</p>
+        <Table size="md">
+          <Thead>
+            <Tr>
+              <Th>Name</Th>
+              <Th isNumeric>Value</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            <Tr>
+              <Td>Item A</Td>
+              <Td isNumeric>100</Td>
+            </Tr>
+          </Tbody>
+        </Table>
+      </div>
+      <div>
+        <p style={{ marginBottom: '8px', fontWeight: 600 }}>Large</p>
+        <Table size="lg">
+          <Thead>
+            <Tr>
+              <Th>Name</Th>
+              <Th isNumeric>Value</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            <Tr>
+              <Td>Item A</Td>
+              <Td isNumeric>100</Td>
+            </Tr>
+          </Tbody>
+        </Table>
+      </div>
+    </VStack>
+  ),
+};

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -26,6 +26,9 @@ export { Modal, ModalHeader, ModalBody, ModalFooter, ModalCloseButton } from './
 export { Tooltip } from './Tooltip';
 export { Menu, MenuButton, MenuList, MenuItem, MenuDivider } from './Menu';
 export { Tabs, TabList, Tab, TabPanels, TabPanel } from './Tabs';
+export { Table, Thead, Tbody, Tr, Th, Td } from './Table';
+export { Stat, StatLabel, StatNumber, StatHelpText, StatArrow } from './Stat';
+export { Progress, ProgressLabel } from './Progress';
 
 export { default as ProgressBar } from './ProgressBar';
 export { default as EmptyState } from './EmptyState';
@@ -63,3 +66,6 @@ export type { ModalProps, ModalSize, ModalHeaderProps, ModalBodyProps, ModalFoot
 export type { TooltipProps, TooltipPlacement } from './Tooltip';
 export type { MenuProps, MenuButtonProps, MenuListProps, MenuItemProps, MenuDividerProps } from './Menu';
 export type { TabsProps, TabsVariant, TabListProps, TabProps, TabPanelsProps, TabPanelProps } from './Tabs';
+export type { TableProps, TableSize, TableVariant, TheadProps, TbodyProps, TrProps, ThProps, TdProps } from './Table';
+export type { StatProps, StatLabelProps, StatNumberProps, StatHelpTextProps, StatArrowProps, StatArrowType } from './Stat';
+export type { ProgressProps, ProgressSize, ProgressColorScheme, ProgressLabelProps } from './Progress';


### PR DESCRIPTION
## Summary
- Table コンポーネント (simple/striped variants、sm/md/lg サイズ)
- Stat コンポーネント (統計表示、増減矢印)
- Progress コンポーネント (プログレスバー、stripe/animated/indeterminate対応)
- Storybookストーリー追加

## Test plan
- [ ] `npm run build` でビルド成功を確認
- [ ] Storybookで各コンポーネントの表示確認

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)