### PR TITLE
Modalコンポーネント（ConfirmModal, FormModal）をCSS Modulesに移行

### DIFF
--- a/src/components/modal/ConfirmModal.tsx
+++ b/src/components/modal/ConfirmModal.tsx
@@ -1,22 +1,10 @@
-import {
-  Modal,
-  ModalOverlay,
-  ModalContent,
-  ModalHeader,
-  ModalFooter,
-  ModalBody,
-  ModalCloseButton,
-  Button,
-  Text,
-  HStack,
-  Icon,
-  VStack,
-} from '@chakra-ui/react';
-import { motion } from 'framer-motion';
 import { IconType } from 'react-icons';
 import { FiAlertTriangle } from 'react-icons/fi';
+import { Modal, ModalHeader, ModalBody, ModalFooter } from '../ui/Modal';
+import Button from '../ui/Button';
+import styles from '../../styles/components/confirm-modal.module.css';
 
-const MotionModalContent = motion(ModalContent);
+type IconColor = 'orange' | 'red' | 'blue' | 'green';
 
 interface ConfirmModalProps {
   isOpen: boolean;
@@ -26,11 +14,18 @@ interface ConfirmModalProps {
   message: string;
   confirmLabel?: string;
   cancelLabel?: string;
-  confirmColorScheme?: string;
+  confirmVariant?: 'primary' | 'danger';
   icon?: IconType;
-  iconColor?: string;
+  iconColor?: IconColor;
   isLoading?: boolean;
 }
+
+const iconColorClassMap: Record<IconColor, string> = {
+  orange: styles.iconOrange,
+  red: styles.iconRed,
+  blue: styles.iconBlue,
+  green: styles.iconGreen,
+};
 
 export default function ConfirmModal({
   isOpen,
@@ -40,44 +35,28 @@ export default function ConfirmModal({
   message,
   confirmLabel = '確認',
   cancelLabel = 'キャンセル',
-  confirmColorScheme = 'red',
-  icon = FiAlertTriangle,
-  iconColor = 'orange.500',
+  confirmVariant = 'danger',
+  icon: Icon = FiAlertTriangle,
+  iconColor = 'orange',
   isLoading = false,
 }: ConfirmModalProps) {
   return (
-    <Modal isOpen={isOpen} onClose={onClose} isCentered motionPreset="slideInBottom">
-      <ModalOverlay />
-      <MotionModalContent
-        initial={{ opacity: 0, scale: 0.9 }}
-        animate={{ opacity: 1, scale: 1 }}
-        exit={{ opacity: 0, scale: 0.9 }}
-      >
-        <ModalHeader>{title}</ModalHeader>
-        <ModalCloseButton />
-        <ModalBody>
-          <VStack spacing={4} align="start">
-            <HStack spacing={3}>
-              <Icon as={icon} boxSize={6} color={iconColor} />
-              <Text>{message}</Text>
-            </HStack>
-          </VStack>
-        </ModalBody>
-        <ModalFooter>
-          <HStack spacing={3}>
-            <Button variant="ghost" onClick={onClose} isDisabled={isLoading}>
-              {cancelLabel}
-            </Button>
-            <Button
-              colorScheme={confirmColorScheme}
-              onClick={onConfirm}
-              isLoading={isLoading}
-            >
-              {confirmLabel}
-            </Button>
-          </HStack>
-        </ModalFooter>
-      </MotionModalContent>
+    <Modal isOpen={isOpen} onClose={onClose} size="sm">
+      <ModalHeader onClose={onClose}>{title}</ModalHeader>
+      <ModalBody>
+        <div className={styles.messageContainer}>
+          <Icon className={`${styles.icon} ${iconColorClassMap[iconColor]}`} />
+          <p className={styles.message}>{message}</p>
+        </div>
+      </ModalBody>
+      <ModalFooter>
+        <Button variant="ghost" onClick={onClose} disabled={isLoading}>
+          {cancelLabel}
+        </Button>
+        <Button variant={confirmVariant} onClick={onConfirm} isLoading={isLoading}>
+          {confirmLabel}
+        </Button>
+      </ModalFooter>
     </Modal>
   );
 }

--- a/src/components/modal/FormModal.tsx
+++ b/src/components/modal/FormModal.tsx
@@ -1,18 +1,7 @@
-import {
-  Modal,
-  ModalOverlay,
-  ModalContent,
-  ModalHeader,
-  ModalFooter,
-  ModalBody,
-  ModalCloseButton,
-  Button,
-  VStack,
-} from '@chakra-ui/react';
-import { motion } from 'framer-motion';
 import { ReactNode } from 'react';
-
-const MotionModalContent = motion(ModalContent);
+import { Modal, ModalHeader, ModalBody, ModalFooter } from '../ui/Modal';
+import Button from '../ui/Button';
+import styles from '../../styles/components/form-modal.module.css';
 
 interface FormModalProps {
   isOpen: boolean;
@@ -22,7 +11,7 @@ interface FormModalProps {
   children: ReactNode;
   submitLabel?: string;
   cancelLabel?: string;
-  submitColorScheme?: string;
+  submitVariant?: 'primary' | 'danger';
   isLoading?: boolean;
   size?: 'sm' | 'md' | 'lg' | 'xl';
 }
@@ -35,39 +24,32 @@ export default function FormModal({
   children,
   submitLabel = '保存',
   cancelLabel = 'キャンセル',
-  submitColorScheme = 'primary',
+  submitVariant = 'primary',
   isLoading = false,
   size = 'lg',
 }: FormModalProps) {
   return (
-    <Modal isOpen={isOpen} onClose={onClose} motionPreset="slideInBottom" size={size}>
-      <ModalOverlay />
-      <MotionModalContent
-        initial={{ opacity: 0, scale: 0.9 }}
-        animate={{ opacity: 1, scale: 1 }}
-        exit={{ opacity: 0, scale: 0.9 }}
+    <Modal isOpen={isOpen} onClose={onClose} size={size}>
+      <ModalHeader onClose={onClose}>{title}</ModalHeader>
+      <form
+        className={styles.form}
+        onSubmit={(e) => {
+          e.preventDefault();
+          onSubmit();
+        }}
       >
-        <ModalHeader>{title}</ModalHeader>
-        <ModalCloseButton />
-        <form
-          onSubmit={(e) => {
-            e.preventDefault();
-            onSubmit();
-          }}
-        >
-          <ModalBody>
-            <VStack spacing={4}>{children}</VStack>
-          </ModalBody>
-          <ModalFooter>
-            <Button variant="ghost" mr={3} onClick={onClose} isDisabled={isLoading}>
-              {cancelLabel}
-            </Button>
-            <Button colorScheme={submitColorScheme} type="submit" isLoading={isLoading}>
-              {submitLabel}
-            </Button>
-          </ModalFooter>
-        </form>
-      </MotionModalContent>
+        <ModalBody>
+          <div className={styles.formBody}>{children}</div>
+        </ModalBody>
+        <ModalFooter>
+          <Button variant="ghost" onClick={onClose} disabled={isLoading}>
+            {cancelLabel}
+          </Button>
+          <Button variant={submitVariant} type="submit" isLoading={isLoading}>
+            {submitLabel}
+          </Button>
+        </ModalFooter>
+      </form>
     </Modal>
   );
 }

--- a/src/styles/components/confirm-modal.module.css
+++ b/src/styles/components/confirm-modal.module.css
@@ -1,0 +1,32 @@
+.messageContainer {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-3);
+}
+
+.icon {
+  flex-shrink: 0;
+  font-size: var(--font-size-xl);
+}
+
+.iconOrange {
+  color: var(--color-orange-500);
+}
+
+.iconRed {
+  color: var(--color-red-500);
+}
+
+.iconBlue {
+  color: var(--color-primary-500);
+}
+
+.iconGreen {
+  color: var(--color-success-500);
+}
+
+.message {
+  font-size: var(--font-size-md);
+  color: var(--color-gray-700);
+  line-height: 1.5;
+}

--- a/src/styles/components/form-modal.module.css
+++ b/src/styles/components/form-modal.module.css
@@ -1,0 +1,9 @@
+.form {
+  display: contents;
+}
+
+.formBody {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+}


### PR DESCRIPTION
## Summary
- ConfirmModal.tsxをChakra UIから既存のModal UIコンポーネント + CSS Modulesに移行
- FormModal.tsxをChakra UIから既存のModal UIコンポーネント + CSS Modulesに移行
- Modal.tsx自体は既にCSS Modules移行済みのため変更なし

## 変更点
- `confirmColorScheme`/`submitColorScheme`を`variant`型（'primary' | 'danger'）に変更
- `iconColor`を文字列から`IconColor`型に変更

## Test plan
- [ ] ビルドが成功することを確認 ✅
- [ ] ConfirmModalが正しく表示されることを確認
- [ ] FormModalが正しく表示されることを確認

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)