### PR TITLE
#85 ダッシュボードページを共通UIコンポーネントに移行

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,5 @@
 import {
   Box,
-  SimpleGrid,
   Card,
   CardHeader,
   CardBody,
@@ -15,11 +14,11 @@ import {
   HStack,
   Avatar,
   Badge,
-  Icon,
-} from '@chakra-ui/react';
+} from '@/src/components/ui';
 import { FiFolderPlus, FiCheckSquare, FiClock, FiAlertCircle } from 'react-icons/fi';
 import Layout from '../components/layout/Layout';
 import { calculateStatistics, mockTasks, mockProjects } from '../lib/mockData';
+import styles from '../styles/pages/dashboard.module.css';
 
 export default function Home() {
   const stats = calculateStatistics();
@@ -29,7 +28,7 @@ export default function Home() {
       case 'urgent':
         return 'red';
       case 'high':
-        return 'orange';
+        return 'yellow';
       case 'medium':
         return 'blue';
       case 'low':
@@ -61,7 +60,7 @@ export default function Home() {
       case 'planning':
         return 'gray';
       case 'on-hold':
-        return 'orange';
+        return 'yellow';
       default:
         return 'gray';
     }
@@ -131,24 +130,26 @@ export default function Home() {
     <Layout>
       <VStack align="stretch" spacing={6}>
         <Box>
-          <Heading size="lg" mb={2}>
+          <Heading size="lg" style={{ marginBottom: 'var(--spacing-2)' }}>
             ダッシュボード
           </Heading>
-          <Text color="gray.600">
+          <Text color="var(--color-gray-600)">
             プロジェクトとタスクの概要を確認できます
           </Text>
         </Box>
 
-        <SimpleGrid columns={{ base: 1, md: 2, lg: 4 }} spacing={6}>
-          <Card style={{ background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)', color: 'white' }}>
+        <div className={styles.statsGrid}>
+          <Card className={styles.gradientCard}>
             <CardBody>
               <Stat>
-                <HStack mb={2}>
-                  <Icon as={FiFolderPlus} boxSize={5} style={{ filter: 'drop-shadow(0 2px 4px rgba(0,0,0,0.2))' }} />
-                  <StatLabel style={{ color: 'rgba(255,255,255,0.9)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>総プロジェクト数</StatLabel>
+                <HStack spacing={2} style={{ marginBottom: 'var(--spacing-2)' }}>
+                  <FiFolderPlus size={20} className={styles.gradientIcon} />
+                  <StatLabel className={styles.gradientLabel}>総プロジェクト数</StatLabel>
                 </HStack>
-                <StatNumber fontSize="3xl" style={{ textShadow: '0 2px 4px rgba(0,0,0,0.2)' }}>{stats.totalProjects}</StatNumber>
-                <StatHelpText style={{ color: 'rgba(255,255,255,0.8)' }}>
+                <StatNumber className={styles.gradientNumber} style={{ fontSize: 'var(--font-size-3xl)' }}>
+                  {stats.totalProjects}
+                </StatNumber>
+                <StatHelpText className={styles.gradientHelpText}>
                   <StatArrow type="increase" />
                   進行中 {stats.activeProjects}件
                 </StatHelpText>
@@ -159,11 +160,13 @@ export default function Home() {
           <Card>
             <CardBody>
               <Stat>
-                <HStack mb={2}>
-                  <Icon as={FiCheckSquare} boxSize={5} color="accent.500" />
+                <HStack spacing={2} style={{ marginBottom: 'var(--spacing-2)' }}>
+                  <FiCheckSquare size={20} style={{ color: 'var(--color-accent-500)' }} />
                   <StatLabel>総タスク数</StatLabel>
                 </HStack>
-                <StatNumber fontSize="3xl">{stats.totalTasks}</StatNumber>
+                <StatNumber style={{ fontSize: 'var(--font-size-3xl)' }}>
+                  {stats.totalTasks}
+                </StatNumber>
                 <StatHelpText>
                   完了 {stats.completedTasks}件
                 </StatHelpText>
@@ -174,11 +177,13 @@ export default function Home() {
           <Card>
             <CardBody>
               <Stat>
-                <HStack mb={2}>
-                  <Icon as={FiClock} boxSize={5} color="blue.500" />
+                <HStack spacing={2} style={{ marginBottom: 'var(--spacing-2)' }}>
+                  <FiClock size={20} style={{ color: 'var(--color-blue-500)' }} />
                   <StatLabel>進行中のタスク</StatLabel>
                 </HStack>
-                <StatNumber fontSize="3xl">{stats.inProgressTasks}</StatNumber>
+                <StatNumber style={{ fontSize: 'var(--font-size-3xl)' }}>
+                  {stats.inProgressTasks}
+                </StatNumber>
                 <StatHelpText>
                   未着手 {stats.todoTasks}件
                 </StatHelpText>
@@ -189,20 +194,22 @@ export default function Home() {
           <Card>
             <CardBody>
               <Stat>
-                <HStack mb={2}>
-                  <Icon as={FiAlertCircle} boxSize={5} color="orange.500" />
+                <HStack spacing={2} style={{ marginBottom: 'var(--spacing-2)' }}>
+                  <FiAlertCircle size={20} style={{ color: 'var(--color-yellow-500)' }} />
                   <StatLabel>遅延プロジェクト</StatLabel>
                 </HStack>
-                <StatNumber fontSize="3xl">{stats.delayedProjects}</StatNumber>
+                <StatNumber style={{ fontSize: 'var(--font-size-3xl)' }}>
+                  {stats.delayedProjects}
+                </StatNumber>
                 <StatHelpText>
                   {stats.delayedProjects > 0 ? '要対応' : '問題なし'}
                 </StatHelpText>
               </Stat>
             </CardBody>
           </Card>
-        </SimpleGrid>
+        </div>
 
-        <SimpleGrid columns={{ base: 1, lg: 2 }} spacing={6}>
+        <div className={styles.contentGrid}>
           <Card>
             <CardHeader>
               <Heading size="md">最近のタスク</Heading>
@@ -214,16 +221,8 @@ export default function Home() {
                   const isOverdue = new Date(task.dueDate) < new Date() && task.status !== 'completed';
 
                   return (
-                    <Box
-                      key={task.id}
-                      p={4}
-                      borderRadius="md"
-                      border="1px"
-                      borderColor="gray.200"
-                      _hover={{ borderColor: 'primary.300', bg: 'gray.50' }}
-                      transition="all 0.2s"
-                    >
-                      <HStack justify="space-between" mb={2}>
+                    <div key={task.id} className={styles.taskItem}>
+                      <HStack style={{ justifyContent: 'space-between', marginBottom: 'var(--spacing-2)' }}>
                         <Text fontWeight="semibold" fontSize="sm">
                           {task.title}
                         </Text>
@@ -231,31 +230,35 @@ export default function Home() {
                           {getTaskPriorityLabel(task.priority)}
                         </Badge>
                       </HStack>
-                      <Text fontSize="sm" color="gray.600" mb={3} noOfLines={2}>
+                      <Text fontSize="sm" color="var(--color-gray-600)" noOfLines={2} style={{ marginBottom: 'var(--spacing-3)' }}>
                         {task.description}
                       </Text>
-                      <HStack justify="space-between" fontSize="xs">
+                      <HStack style={{ justifyContent: 'space-between', fontSize: 'var(--font-size-xs)' }}>
                         <HStack spacing={2}>
                           <Badge colorScheme={getTaskStatusColor(task.status)} variant="subtle">
                             {getTaskStatusLabel(task.status)}
                           </Badge>
                           {project && (
-                            <Text color="gray.500">{project.name}</Text>
+                            <Text as="span" color="var(--color-gray-500)">{project.name}</Text>
                           )}
                         </HStack>
                         <HStack spacing={2}>
                           {task.assignee && (
                             <HStack spacing={1}>
                               <Avatar size="xs" name={task.assignee.name} src={task.assignee.avatar} />
-                              <Text color="gray.600">{task.assignee.name}</Text>
+                              <Text as="span" color="var(--color-gray-600)">{task.assignee.name}</Text>
                             </HStack>
                           )}
-                          <Text color={isOverdue ? 'red.500' : 'gray.500'} fontWeight={isOverdue ? 'semibold' : 'normal'}>
+                          <Text
+                            as="span"
+                            color={isOverdue ? 'var(--color-red-500)' : 'var(--color-gray-500)'}
+                            fontWeight={isOverdue ? 'semibold' : 'normal'}
+                          >
                             {formatDate(task.dueDate)}
                           </Text>
                         </HStack>
                       </HStack>
-                    </Box>
+                    </div>
                   );
                 })}
               </VStack>
@@ -269,16 +272,8 @@ export default function Home() {
             <CardBody>
               <VStack align="stretch" spacing={4}>
                 {recentProjects.map((project) => (
-                  <Box
-                    key={project.id}
-                    p={4}
-                    borderRadius="md"
-                    border="1px"
-                    borderColor="gray.200"
-                    _hover={{ borderColor: 'primary.300', bg: 'gray.50' }}
-                    transition="all 0.2s"
-                  >
-                    <HStack justify="space-between" mb={2}>
+                  <div key={project.id} className={styles.projectItem}>
+                    <HStack style={{ justifyContent: 'space-between', marginBottom: 'var(--spacing-2)' }}>
                       <Text fontWeight="semibold" fontSize="sm">
                         {project.name}
                       </Text>
@@ -286,40 +281,38 @@ export default function Home() {
                         {getProjectStatusLabel(project.status)}
                       </Badge>
                     </HStack>
-                    <Text fontSize="sm" color="gray.600" mb={3} noOfLines={2}>
+                    <Text fontSize="sm" color="var(--color-gray-600)" noOfLines={2} style={{ marginBottom: 'var(--spacing-3)' }}>
                       {project.description}
                     </Text>
                     <VStack align="stretch" spacing={2}>
-                      <HStack justify="space-between" fontSize="xs">
-                        <Text color="gray.500">進捗率</Text>
-                        <Text fontWeight="semibold" color="primary.600">
+                      <HStack style={{ justifyContent: 'space-between', fontSize: 'var(--font-size-xs)' }}>
+                        <Text as="span" color="var(--color-gray-500)">進捗率</Text>
+                        <Text as="span" fontWeight="semibold" color="var(--color-primary-600)">
                           {project.progress}%
                         </Text>
                       </HStack>
-                      <Box h="6px" bg="gray.200" borderRadius="full" overflow="hidden">
-                        <Box
-                          h="full"
-                          bg="primary.500"
-                          w={`${project.progress}%`}
-                          transition="width 0.3s"
+                      <div className={styles.progressBar}>
+                        <div
+                          className={styles.progressFill}
+                          style={{ width: `${project.progress}%` }}
                         />
-                      </Box>
-                      <HStack justify="space-between" fontSize="xs">
+                      </div>
+                      <HStack style={{ justifyContent: 'space-between', fontSize: 'var(--font-size-xs)' }}>
                         <HStack spacing={1}>
                           <Avatar size="xs" name={project.owner.name} src={project.owner.avatar} />
-                          <Text color="gray.600">{project.owner.name}</Text>
+                          <Text as="span" color="var(--color-gray-600)">{project.owner.name}</Text>
                         </HStack>
-                        <Text color="gray.500">
+                        <Text as="span" color="var(--color-gray-500)">
                           {formatDate(project.startDate)} - {formatDate(project.endDate)}
                         </Text>
                       </HStack>
                     </VStack>
-                  </Box>
+                  </div>
                 ))}
               </VStack>
             </CardBody>
           </Card>
-        </SimpleGrid>
+        </div>
       </VStack>
     </Layout>
   );

--- a/src/styles/pages/dashboard.module.css
+++ b/src/styles/pages/dashboard.module.css
@@ -1,0 +1,89 @@
+.statsGrid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--spacing-6);
+}
+
+@media (min-width: 768px) {
+  .statsGrid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 1024px) {
+  .statsGrid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+.contentGrid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--spacing-6);
+}
+
+@media (min-width: 1024px) {
+  .contentGrid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.gradientCard {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+}
+
+.gradientIcon {
+  filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.2));
+}
+
+.gradientLabel {
+  color: rgba(255, 255, 255, 0.9);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.gradientNumber {
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.gradientHelpText {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.taskItem {
+  padding: var(--spacing-4);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-gray-200);
+  transition: all 0.2s;
+}
+
+.taskItem:hover {
+  border-color: var(--color-primary-300);
+  background-color: var(--color-gray-50);
+}
+
+.projectItem {
+  padding: var(--spacing-4);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-gray-200);
+  transition: all 0.2s;
+}
+
+.projectItem:hover {
+  border-color: var(--color-primary-300);
+  background-color: var(--color-gray-50);
+}
+
+.progressBar {
+  height: 6px;
+  background-color: var(--color-gray-200);
+  border-radius: var(--radius-full);
+  overflow: hidden;
+}
+
+.progressFill {
+  height: 100%;
+  background-color: var(--color-primary-500);
+  transition: width 0.3s;
+}


### PR DESCRIPTION
## Summary
- Chakra UIインポートを`@/src/components/ui`に変更
- `SimpleGrid`, `Icon`等のChakra UI固有コンポーネントを削除・代替
- レスポンシブグリッド用にページ固有CSS Module（`dashboard.module.css`）を作成
- react-iconsを直接使用（FiFolderPlus, FiCheckSquare等）
- colorScheme `orange` → `yellow` に変更（共通UIコンポーネントの制約）

## Test plan
- [ ] ダッシュボードページが正常に表示されることを確認
- [ ] レスポンシブレイアウト（モバイル→タブレット→デスクトップ）が動作することを確認
- [ ] 統計カード、タスクリスト、プロジェクトリストが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)