### PR TITLE
#87 プロジェクト一覧ページを共通UIコンポーネントに移行

### DIFF
--- a/src/pages/projects/index.tsx
+++ b/src/pages/projects/index.tsx
@@ -16,16 +16,13 @@ import {
   AvatarGroup,
   Button,
   Input,
-  InputGroup,
-  InputLeftElement,
   Menu,
   MenuButton,
   MenuList,
   MenuItem,
-  IconButton,
   Tooltip,
   Progress,
-} from '@chakra-ui/react';
+} from '@/src/components/ui';
 import {
   FiSearch,
   FiPlus,
@@ -35,12 +32,10 @@ import {
   FiEye,
   FiUsers,
 } from 'react-icons/fi';
-import { motion } from 'framer-motion';
 import { useRouter } from 'next/router';
 import Layout from '../../components/layout/Layout';
 import { mockProjects } from '../../lib/mockData';
-
-const MotionTr = motion(Tr);
+import pageStyles from '../../styles/pages/projects.module.css';
 
 export default function ProjectsPage() {
   const router = useRouter();
@@ -55,7 +50,7 @@ export default function ProjectsPage() {
       case 'planning':
         return 'gray';
       case 'on-hold':
-        return 'orange';
+        return 'yellow';
       default:
         return 'gray';
     }
@@ -84,6 +79,13 @@ export default function ProjectsPage() {
     });
   };
 
+  const getProgressColorScheme = (progress: number) => {
+    if (progress >= 75) return 'green';
+    if (progress >= 50) return 'blue';
+    if (progress >= 25) return 'yellow';
+    return 'red';
+  };
+
   const filteredProjects = mockProjects.filter(
     (project) =>
       project.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
@@ -95,42 +97,39 @@ export default function ProjectsPage() {
     <Layout>
       <VStack align="stretch" spacing={6}>
         <Box>
-          <Heading size="lg" mb={2}>
+          <Heading size="lg" style={{ marginBottom: 'var(--spacing-2)' }}>
             プロジェクト一覧
           </Heading>
-          <Text color="gray.600">
+          <Text color="var(--color-gray-600)">
             すべてのプロジェクトを管理できます
           </Text>
         </Box>
 
-        <HStack justify="space-between">
-          <InputGroup maxW="400px">
-            <InputLeftElement pointerEvents="none">
-              <FiSearch color="gray" />
-            </InputLeftElement>
+        <HStack style={{ justifyContent: 'space-between' }}>
+          <div className={pageStyles.searchContainer}>
+            <FiSearch className={pageStyles.searchIcon} />
             <Input
               placeholder="プロジェクトを検索..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              bg="white"
+              className={pageStyles.searchInput}
             />
-          </InputGroup>
+          </div>
 
           <Button
-            leftIcon={<FiPlus />}
             colorScheme="primary"
             onClick={() => {
-              // 新規作成ハンドラー
               console.log('新規プロジェクト作成');
             }}
           >
+            <FiPlus style={{ marginRight: 'var(--spacing-2)' }} />
             新規プロジェクト
           </Button>
         </HStack>
 
-        <Box bg="white" borderRadius="lg" boxShadow="sm" overflow="hidden">
+        <div className={pageStyles.tableContainer}>
           <Table variant="simple">
-            <Thead bg="gray.50">
+            <Thead style={{ backgroundColor: 'var(--color-gray-50)' }}>
               <Tr>
                 <Th>プロジェクト名</Th>
                 <Th>オーナー</Th>
@@ -138,24 +137,20 @@ export default function ProjectsPage() {
                 <Th>ステータス</Th>
                 <Th>進捗</Th>
                 <Th>期限</Th>
-                <Th width="50px">操作</Th>
+                <Th style={{ width: '50px' }}>操作</Th>
               </Tr>
             </Thead>
             <Tbody>
               {filteredProjects.map((project) => (
-                <MotionTr
+                <Tr
                   key={project.id}
-                  initial={{ opacity: 0, y: 10 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  whileHover={{ backgroundColor: 'rgba(0, 0, 0, 0.02)' }}
-                  transition={{ duration: 0.2 }}
-                  cursor="pointer"
+                  className={pageStyles.tableRow}
                   onClick={() => router.push(`/projects/${project.id}`)}
                 >
                   <Td>
-                    <VStack align="start" spacing={1}>
+                    <VStack align="stretch" spacing={1}>
                       <Text fontWeight="semibold">{project.name}</Text>
-                      <Text fontSize="sm" color="gray.600" noOfLines={1}>
+                      <Text fontSize="sm" color="var(--color-gray-600)" noOfLines={1}>
                         {project.description}
                       </Text>
                     </VStack>
@@ -172,7 +167,7 @@ export default function ProjectsPage() {
                   </Td>
                   <Td>
                     <Tooltip
-                      label={project.members.map((m) => m.name).join(', ')}
+                      content={project.members.map((m) => m.name).join(', ')}
                       placement="top"
                     >
                       <HStack spacing={2}>
@@ -185,8 +180,8 @@ export default function ProjectsPage() {
                             />
                           ))}
                         </AvatarGroup>
-                        <Text fontSize="sm" color="gray.600">
-                          <FiUsers style={{ display: 'inline', marginRight: '4px' }} />
+                        <Text as="span" fontSize="sm" color="var(--color-gray-600)">
+                          <FiUsers style={{ display: 'inline', marginRight: '4px', verticalAlign: 'middle' }} />
                           {project.members.length}
                         </Text>
                       </HStack>
@@ -198,40 +193,30 @@ export default function ProjectsPage() {
                     </Badge>
                   </Td>
                   <Td>
-                    <VStack align="stretch" spacing={1}>
+                    <div className={pageStyles.progressContainer}>
                       <Text fontSize="sm" fontWeight="semibold">
                         {project.progress}%
                       </Text>
                       <Progress
                         value={project.progress}
                         size="sm"
-                        colorScheme={
-                          project.progress >= 75
-                            ? 'green'
-                            : project.progress >= 50
-                            ? 'blue'
-                            : project.progress >= 25
-                            ? 'orange'
-                            : 'red'
-                        }
-                        borderRadius="full"
+                        colorScheme={getProgressColorScheme(project.progress)}
                       />
-                    </VStack>
+                    </div>
                   </Td>
                   <Td>
-                    <Text fontSize="sm" color="gray.600">
+                    <Text fontSize="sm" color="var(--color-gray-600)">
                       {formatDate(project.endDate)}
                     </Text>
                   </Td>
                   <Td onClick={(e) => e.stopPropagation()}>
                     <Menu>
                       <MenuButton
-                        as={IconButton}
-                        icon={<FiMoreVertical />}
-                        variant="ghost"
-                        size="sm"
+                        className={pageStyles.actionButton}
                         aria-label="アクション"
-                      />
+                      >
+                        <FiMoreVertical />
+                      </MenuButton>
                       <MenuList>
                         <MenuItem
                           icon={<FiEye />}
@@ -249,7 +234,7 @@ export default function ProjectsPage() {
                         </MenuItem>
                         <MenuItem
                           icon={<FiTrash2 />}
-                          color="red.500"
+                          className={pageStyles.deleteItem}
                           onClick={() => {
                             console.log('削除:', project.id);
                           }}
@@ -259,21 +244,21 @@ export default function ProjectsPage() {
                       </MenuList>
                     </Menu>
                   </Td>
-                </MotionTr>
+                </Tr>
               ))}
             </Tbody>
           </Table>
 
           {filteredProjects.length === 0 && (
-            <Box py={10} textAlign="center">
-              <Text color="gray.500">
+            <div className={pageStyles.emptyState}>
+              <Text color="var(--color-gray-500)">
                 検索条件に一致するプロジェクトが見つかりませんでした
               </Text>
-            </Box>
+            </div>
           )}
-        </Box>
+        </div>
 
-        <HStack justify="space-between" fontSize="sm" color="gray.600">
+        <HStack style={{ justifyContent: 'space-between', fontSize: 'var(--font-size-sm)', color: 'var(--color-gray-600)' }}>
           <Text>全 {filteredProjects.length} 件のプロジェクト</Text>
           <HStack spacing={4}>
             <Badge colorScheme="blue">
@@ -285,7 +270,7 @@ export default function ProjectsPage() {
             <Badge colorScheme="gray">
               計画中 {mockProjects.filter((p) => p.status === 'planning').length}
             </Badge>
-            <Badge colorScheme="orange">
+            <Badge colorScheme="yellow">
               保留 {mockProjects.filter((p) => p.status === 'on-hold').length}
             </Badge>
           </HStack>

--- a/src/styles/pages/projects.module.css
+++ b/src/styles/pages/projects.module.css
@@ -1,0 +1,69 @@
+.searchContainer {
+  position: relative;
+  max-width: 400px;
+}
+
+.searchIcon {
+  position: absolute;
+  left: var(--spacing-3);
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--color-gray-500);
+  pointer-events: none;
+  z-index: 1;
+}
+
+.searchInput {
+  padding-left: var(--spacing-10);
+  background-color: white;
+}
+
+.tableContainer {
+  background-color: white;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+  overflow: hidden;
+}
+
+.tableRow {
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.tableRow:hover {
+  background-color: rgba(0, 0, 0, 0.02);
+}
+
+.actionButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  color: var(--color-gray-600);
+  transition: background-color 0.15s ease;
+}
+
+.actionButton:hover {
+  background-color: var(--color-gray-100);
+}
+
+.deleteItem {
+  color: var(--color-red-500);
+}
+
+.progressContainer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.emptyState {
+  padding: var(--spacing-10) 0;
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- Chakra UIインポートを`@/src/components/ui`に変更
- `InputGroup`, `InputLeftElement`をページ固有CSSで代替
- `IconButton`を`MenuButton` + CSSで代替
- `motion(Tr)`をCSSトランジションで代替
- Tooltip `label` → `content` に変更
- colorScheme `orange` → `yellow` に変更
- ページ固有CSS（`projects.module.css`）を作成

## Test plan
- [ ] プロジェクト一覧ページが正常に表示されることを確認
- [ ] 検索機能が動作することを確認
- [ ] テーブル行クリックで詳細ページへ遷移することを確認
- [ ] アクションメニューが正しく動作することを確認
- [ ] プログレスバーが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)