### PR TITLE
#165, #166, #167 InputGroup, IconButton, orange カラー追加

### DIFF
--- a/src/components/ui/Badge.module.css
+++ b/src/components/ui/Badge.module.css
@@ -46,6 +46,11 @@
   color: white;
 }
 
+.solid.orange {
+  background-color: var(--color-orange-500);
+  color: white;
+}
+
 /* Subtle variant */
 .subtle.gray {
   background-color: var(--color-gray-100);
@@ -82,6 +87,11 @@
   color: var(--color-purple-700);
 }
 
+.subtle.orange {
+  background-color: var(--color-orange-100);
+  color: var(--color-orange-700);
+}
+
 /* Outline variant */
 .outline {
   background-color: transparent;
@@ -114,4 +124,8 @@
 
 .outline.purple {
   color: var(--color-purple-500);
+}
+
+.outline.orange {
+  color: var(--color-orange-500);
 }

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styles from './Badge.module.css';
 
 export type BadgeVariant = 'solid' | 'subtle' | 'outline';
-export type BadgeColorScheme = 'gray' | 'primary' | 'green' | 'red' | 'yellow' | 'blue' | 'purple';
+export type BadgeColorScheme = 'gray' | 'primary' | 'green' | 'red' | 'yellow' | 'blue' | 'purple' | 'orange';
 
 export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
   variant?: BadgeVariant;

--- a/src/components/ui/IconButton.module.css
+++ b/src/components/ui/IconButton.module.css
@@ -1,0 +1,197 @@
+.iconButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  border-radius: var(--radius-md);
+  flex-shrink: 0;
+}
+
+.iconButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.round {
+  border-radius: 9999px;
+}
+
+/* Sizes */
+.sm {
+  width: 32px;
+  height: 32px;
+  font-size: var(--font-size-sm);
+}
+
+.md {
+  width: 40px;
+  height: 40px;
+  font-size: var(--font-size-md);
+}
+
+.lg {
+  width: 48px;
+  height: 48px;
+  font-size: var(--font-size-lg);
+}
+
+/* Solid variant */
+.solid.primary {
+  background-color: var(--color-primary-500);
+  color: white;
+}
+
+.solid.primary:hover:not(:disabled) {
+  background-color: var(--color-primary-600);
+}
+
+.solid.gray {
+  background-color: var(--color-gray-100);
+  color: var(--color-gray-700);
+}
+
+.solid.gray:hover:not(:disabled) {
+  background-color: var(--color-gray-200);
+}
+
+.solid.red {
+  background-color: var(--color-red-500);
+  color: white;
+}
+
+.solid.red:hover:not(:disabled) {
+  background-color: var(--color-red-600);
+}
+
+.solid.green {
+  background-color: var(--color-green-500);
+  color: white;
+}
+
+.solid.green:hover:not(:disabled) {
+  background-color: var(--color-green-600);
+}
+
+.solid.blue {
+  background-color: var(--color-blue-500);
+  color: white;
+}
+
+.solid.blue:hover:not(:disabled) {
+  background-color: var(--color-blue-600);
+}
+
+/* Outline variant */
+.outline {
+  background-color: transparent;
+  border: 1px solid currentColor;
+}
+
+.outline.primary {
+  color: var(--color-primary-500);
+}
+
+.outline.primary:hover:not(:disabled) {
+  background-color: var(--color-primary-50);
+}
+
+.outline.gray {
+  color: var(--color-gray-500);
+  border-color: var(--color-gray-300);
+}
+
+.outline.gray:hover:not(:disabled) {
+  background-color: var(--color-gray-100);
+}
+
+.outline.red {
+  color: var(--color-red-500);
+}
+
+.outline.red:hover:not(:disabled) {
+  background-color: var(--color-red-50);
+}
+
+.outline.green {
+  color: var(--color-green-500);
+}
+
+.outline.green:hover:not(:disabled) {
+  background-color: var(--color-green-50);
+}
+
+.outline.blue {
+  color: var(--color-blue-500);
+}
+
+.outline.blue:hover:not(:disabled) {
+  background-color: var(--color-blue-50);
+}
+
+/* Ghost variant */
+.ghost {
+  background-color: transparent;
+  border: none;
+}
+
+.ghost.primary {
+  color: var(--color-primary-500);
+}
+
+.ghost.primary:hover:not(:disabled) {
+  background-color: var(--color-primary-50);
+}
+
+.ghost.gray {
+  color: var(--color-gray-600);
+}
+
+.ghost.gray:hover:not(:disabled) {
+  background-color: var(--color-gray-100);
+}
+
+.ghost.red {
+  color: var(--color-red-500);
+}
+
+.ghost.red:hover:not(:disabled) {
+  background-color: var(--color-red-50);
+}
+
+.ghost.green {
+  color: var(--color-green-500);
+}
+
+.ghost.green:hover:not(:disabled) {
+  background-color: var(--color-green-50);
+}
+
+.ghost.blue {
+  color: var(--color-blue-500);
+}
+
+.ghost.blue:hover:not(:disabled) {
+  background-color: var(--color-blue-50);
+}
+
+/* Loading spinner */
+.loading {
+  pointer-events: none;
+}
+
+.spinner {
+  width: 1em;
+  height: 1em;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/components/ui/IconButton.tsx
+++ b/src/components/ui/IconButton.tsx
@@ -1,0 +1,63 @@
+import React, { forwardRef } from 'react';
+import styles from './IconButton.module.css';
+
+export type IconButtonVariant = 'solid' | 'outline' | 'ghost';
+export type IconButtonColorScheme = 'primary' | 'gray' | 'red' | 'green' | 'blue';
+export type IconButtonSize = 'sm' | 'md' | 'lg';
+
+export interface IconButtonProps extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'children'> {
+  icon: React.ReactNode;
+  'aria-label': string;
+  variant?: IconButtonVariant;
+  colorScheme?: IconButtonColorScheme;
+  size?: IconButtonSize;
+  isLoading?: boolean;
+  isDisabled?: boolean;
+  isRound?: boolean;
+}
+
+export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
+  (
+    {
+      icon,
+      'aria-label': ariaLabel,
+      variant = 'solid',
+      colorScheme = 'gray',
+      size = 'md',
+      isLoading = false,
+      isDisabled = false,
+      isRound = false,
+      className,
+      ...props
+    },
+    ref
+  ) => {
+    const classNames = [
+      styles.iconButton,
+      styles[variant],
+      styles[colorScheme],
+      styles[size],
+      isRound ? styles.round : '',
+      isLoading ? styles.loading : '',
+      className,
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    return (
+      <button
+        ref={ref}
+        className={classNames}
+        disabled={isDisabled || isLoading}
+        aria-label={ariaLabel}
+        {...props}
+      >
+        {isLoading ? <span className={styles.spinner} /> : icon}
+      </button>
+    );
+  }
+);
+
+IconButton.displayName = 'IconButton';
+
+export default IconButton;

--- a/src/components/ui/Input.module.css
+++ b/src/components/ui/Input.module.css
@@ -86,3 +86,71 @@
   border-color: var(--color-red-500);
   box-shadow: 0 0 0 1px var(--color-red-500);
 }
+
+/* InputGroup */
+.inputGroup {
+  position: relative;
+  display: flex;
+  width: 100%;
+  align-items: center;
+}
+
+/* InputElement (共通) */
+.inputElement {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-gray-500);
+  pointer-events: none;
+  z-index: 1;
+}
+
+.inputLeftElement {
+  left: 0;
+}
+
+.inputRightElement {
+  right: 0;
+}
+
+/* Element sizes */
+.elementSm {
+  width: 32px;
+  height: 32px;
+}
+
+.elementMd {
+  width: 40px;
+  height: 40px;
+}
+
+.elementLg {
+  width: 48px;
+  height: 48px;
+}
+
+/* Input with elements - adjust padding */
+.input.withLeftElement.sm {
+  padding-left: 32px;
+}
+
+.input.withLeftElement.md {
+  padding-left: 40px;
+}
+
+.input.withLeftElement.lg {
+  padding-left: 48px;
+}
+
+.input.withRightElement.sm {
+  padding-right: 32px;
+}
+
+.input.withRightElement.md {
+  padding-right: 40px;
+}
+
+.input.withRightElement.lg {
+  padding-right: 48px;
+}

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,8 +1,16 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, createContext, useContext } from 'react';
 import styles from './Input.module.css';
 
 export type InputSize = 'sm' | 'md' | 'lg';
 export type InputVariant = 'outline' | 'filled' | 'flushed';
+
+interface InputGroupContextValue {
+  size?: InputSize;
+  hasLeftElement?: boolean;
+  hasRightElement?: boolean;
+}
+
+const InputGroupContext = createContext<InputGroupContextValue>({});
 
 export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> {
   size?: InputSize;
@@ -14,7 +22,7 @@ export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElem
 export const Input = forwardRef<HTMLInputElement, InputProps>(
   (
     {
-      size = 'md',
+      size: sizeProp = 'md',
       variant = 'outline',
       isInvalid = false,
       isDisabled = false,
@@ -23,11 +31,18 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
     },
     ref
   ) => {
+    const context = useContext(InputGroupContext);
+    const size = context.size || sizeProp;
+    const hasLeftElement = context.hasLeftElement;
+    const hasRightElement = context.hasRightElement;
+
     const classNames = [
       styles.input,
       styles[size],
       styles[variant],
       isInvalid ? styles.invalid : '',
+      hasLeftElement ? styles.withLeftElement : '',
+      hasRightElement ? styles.withRightElement : '',
       className,
     ]
       .filter(Boolean)
@@ -46,5 +61,85 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
 );
 
 Input.displayName = 'Input';
+
+export interface InputGroupProps extends React.HTMLAttributes<HTMLDivElement> {
+  size?: InputSize;
+  children: React.ReactNode;
+}
+
+export const InputGroup = forwardRef<HTMLDivElement, InputGroupProps>(
+  ({ size = 'md', children, className, ...props }, ref) => {
+    const hasLeftElement = React.Children.toArray(children).some(
+      (child) => React.isValidElement(child) && child.type === InputLeftElement
+    );
+    const hasRightElement = React.Children.toArray(children).some(
+      (child) => React.isValidElement(child) && child.type === InputRightElement
+    );
+
+    const classNames = [styles.inputGroup, className].filter(Boolean).join(' ');
+
+    return (
+      <InputGroupContext.Provider value={{ size, hasLeftElement, hasRightElement }}>
+        <div ref={ref} className={classNames} {...props}>
+          {children}
+        </div>
+      </InputGroupContext.Provider>
+    );
+  }
+);
+
+InputGroup.displayName = 'InputGroup';
+
+export interface InputElementProps extends React.HTMLAttributes<HTMLDivElement> {
+  children: React.ReactNode;
+}
+
+export const InputLeftElement = forwardRef<HTMLDivElement, InputElementProps>(
+  ({ children, className, ...props }, ref) => {
+    const context = useContext(InputGroupContext);
+    const size = context.size || 'md';
+
+    const classNames = [
+      styles.inputElement,
+      styles.inputLeftElement,
+      styles[`element${size.charAt(0).toUpperCase() + size.slice(1)}`],
+      className,
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    return (
+      <div ref={ref} className={classNames} {...props}>
+        {children}
+      </div>
+    );
+  }
+);
+
+InputLeftElement.displayName = 'InputLeftElement';
+
+export const InputRightElement = forwardRef<HTMLDivElement, InputElementProps>(
+  ({ children, className, ...props }, ref) => {
+    const context = useContext(InputGroupContext);
+    const size = context.size || 'md';
+
+    const classNames = [
+      styles.inputElement,
+      styles.inputRightElement,
+      styles[`element${size.charAt(0).toUpperCase() + size.slice(1)}`],
+      className,
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    return (
+      <div ref={ref} className={classNames} {...props}>
+        {children}
+      </div>
+    );
+  }
+);
+
+InputRightElement.displayName = 'InputRightElement';
 
 export default Input;

--- a/src/components/ui/Progress.module.css
+++ b/src/components/ui/Progress.module.css
@@ -53,6 +53,10 @@
   background-color: var(--color-gray-500);
 }
 
+.progressBar.orange {
+  background-color: var(--color-orange-500);
+}
+
 /* Striped */
 .striped {
   background-image: linear-gradient(
@@ -135,4 +139,8 @@
 
 .progressLabelValue.gray {
   color: var(--color-gray-600);
+}
+
+.progressLabelValue.orange {
+  color: var(--color-orange-600);
 }

--- a/src/components/ui/Progress.tsx
+++ b/src/components/ui/Progress.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styles from './Progress.module.css';
 
 export type ProgressSize = 'xs' | 'sm' | 'md' | 'lg';
-export type ProgressColorScheme = 'primary' | 'green' | 'blue' | 'red' | 'yellow' | 'gray';
+export type ProgressColorScheme = 'primary' | 'green' | 'blue' | 'red' | 'yellow' | 'gray' | 'orange';
 
 export interface ProgressProps extends React.HTMLAttributes<HTMLDivElement> {
   value: number;

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -9,6 +9,7 @@ export { Text } from './Text';
 export { Heading } from './Heading';
 
 export { Button } from './Button';
+export { IconButton } from './IconButton';
 export { Input, InputGroup, InputLeftElement, InputRightElement } from './Input';
 export { Textarea } from './Textarea';
 export { Select } from './Select';
@@ -46,6 +47,7 @@ export type { SimpleGridProps } from './SimpleGrid';
 export type { TextProps } from './Text';
 export type { HeadingProps } from './Heading';
 export type { ButtonProps, ButtonVariant, ButtonSize, ButtonColorScheme } from './Button';
+export type { IconButtonProps, IconButtonVariant, IconButtonSize, IconButtonColorScheme } from './IconButton';
 export type { InputProps, InputSize, InputVariant, InputGroupProps, InputElementProps } from './Input';
 export type { TextareaProps, TextareaSize } from './Textarea';
 export type { SelectProps, SelectSize } from './Select';

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -9,7 +9,7 @@ export { Text } from './Text';
 export { Heading } from './Heading';
 
 export { Button } from './Button';
-export { Input } from './Input';
+export { Input, InputGroup, InputLeftElement, InputRightElement } from './Input';
 export { Textarea } from './Textarea';
 export { Select } from './Select';
 export { Checkbox } from './Checkbox';
@@ -46,7 +46,7 @@ export type { SimpleGridProps } from './SimpleGrid';
 export type { TextProps } from './Text';
 export type { HeadingProps } from './Heading';
 export type { ButtonProps, ButtonVariant, ButtonSize, ButtonColorScheme } from './Button';
-export type { InputProps, InputSize, InputVariant } from './Input';
+export type { InputProps, InputSize, InputVariant, InputGroupProps, InputElementProps } from './Input';
 export type { TextareaProps, TextareaSize } from './Textarea';
 export type { SelectProps, SelectSize } from './Select';
 export type { CheckboxProps, CheckboxSize, CheckboxColorScheme } from './Checkbox';


### PR DESCRIPTION
## Summary
projects ページ移行の前提となるコンポーネントを追加

- **#165** InputGroup, InputLeftElement, InputRightElement
- **#166** IconButton
- **#167** Badge, Progress に orange カラー

## Test plan
- [x] ビルド成功確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)