### PR TITLE
feat: テキスト系コンポーネント追加 (#172)

### DIFF
--- a/.claude/commands/migrate.md
+++ b/.claude/commands/migrate.md
@@ -25,7 +25,16 @@ docs/migration-work.md の手順に従って作業を実行する。
 
 3. 該当Phaseの手順を実行
 
-4. 完了後、PRを作成
+4. **スクリーンショット取得（必須）**
+   - 作業完了後、比較ページのスクリーンショットを取得
+   - スクリーンショットがない場合はPRを作成しない
+   ```bash
+   mkdir -p screenshots/issue-$ARGUMENTS
+   agent-browser --cdp 9222 open "http://localhost:3000/compare/<Component>"
+   agent-browser --cdp 9222 screenshot "/Users/h/lab-chakra-to-css-modules/screenshots/issue-$ARGUMENTS/compare-<component>.png" --full
+   ```
+
+5. 完了後、PRを作成
 
 ## 参照
 

--- a/.claude/rules/migration.md
+++ b/.claude/rules/migration.md
@@ -17,11 +17,31 @@ git checkout -b issue-<number>
 agent-browserを使用してスクリーンショットを取得する。
 
 ```bash
+mkdir -p screenshots/issue-<number>
 agent-browser --cdp 9222 open "http://localhost:3000/<path>"
-agent-browser --cdp 9222 screenshot "screenshots/issue-<number>/<name>.png" --full
+agent-browser --cdp 9222 screenshot "/Users/h/lab-chakra-to-css-modules/screenshots/issue-<number>/<name>.png" --full
 ```
 
-## Before/After必須
+## Phase 1: コンポーネント作成時
+
+比較ページ（/compare/<Component>）のスクリーンショットを取得して確認する。
+
+### 手順
+
+1. コンポーネント実装
+2. 比較ページ作成
+3. **スクリーンショット取得（PR作成前に必須）**
+4. Chakra UIとCSS Modules版の表示が一致することを確認
+5. PR作成
+
+### 保存先
+
+```
+screenshots/issue-<number>/
+└── compare-<component>.png
+```
+
+## Phase 2, 3, 4: Before/After必須
 
 移行作業（Phase 2, 3, 4）では、Before/Afterのスクリーンショット取得を必ず行う。
 
@@ -42,4 +62,4 @@ screenshots/issue-<number>/
 
 ## 違反した場合
 
-スクリーンショットを取得せずに作業を進めた場合、その作業は無効とする。
+スクリーンショットを取得せずにPRを作成した場合、その作業は無効とする。

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git add:*)",
+      "Bash(git commit -m \"$\\(cat <<''EOF''\nfix: VStackのデフォルトalignをstretchに修正、色のCSS変数追加\n\n- VStackのデフォルトalignをcenterからstretchに変更（Chakra UI互換）\n- purple, orange, teal, cyan, pinkの色変数を追加\n\nCo-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>\nEOF\n\\)\")",
+      "Bash(git push)"
+    ]
+  }
+}

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -7,11 +7,24 @@ user-invocable: true
 
 # PR作成
 
+## 前提条件（必須）
+
+**スクリーンショットの確認**
+- PR作成前に必ず比較ページのスクリーンショットを取得すること
+- スクリーンショットがない場合はPRを作成しない
+
+```bash
+# スクリーンショット取得
+agent-browser --cdp 9222 open "http://localhost:3000/compare/<Component>"
+agent-browser --cdp 9222 screenshot "/Users/h/lab-chakra-to-css-modules/screenshots/issue-<number>/compare-<component>.png" --full
+```
+
 ## 手順
 
-1. 現在のブランチ名からissue番号を取得
-2. 変更ファイルを確認
-3. PRを作成
+1. スクリーンショットが取得済みか確認
+2. 現在のブランチ名からissue番号を取得
+3. 変更ファイルを確認
+4. PRを作成
 
 ## コマンド
 

--- a/.claude/todos/issue-172-reviewer.md
+++ b/.claude/todos/issue-172-reviewer.md
@@ -1,0 +1,29 @@
+# Issue #172 Reviewer TODO
+
+## レビュー対象コンポーネント
+- Text
+- Heading
+
+## レビューチェックリスト
+
+### コードレビュー
+1. [pending] Text.tsx の型定義が正しいか確認
+2. [pending] Text.tsx のprops（fontSize, fontWeight, color, mb, mt, noOfLines, textAlign, maxW, minW）が正しく実装されているか確認
+3. [pending] Heading.tsx の型定義が正しいか確認
+4. [pending] Heading.tsx のprops（size, mb, color）が正しく実装されているか確認
+5. [pending] CSS Modulesのスタイルが適切か確認
+6. [pending] noOfLinesの行数制限が正しく動作するか確認
+
+### 動作確認
+7. [pending] /compare/Text ページで動作確認
+8. [pending] Chakra版と新版のTextが同じ見た目になっているか確認
+9. [pending] Chakra版と新版のHeadingが同じ見た目になっているか確認
+
+### スクリーンショット
+10. [pending] Before スクリーンショット取得（作業前は不要、既存はChakra版）
+11. [pending] After スクリーンショット取得
+12. [pending] Before/After の比較
+
+### 問題対応
+13. [pending] 問題があれば修正
+14. [pending] 再度ビルド確認

--- a/.claude/todos/issue-172-worker.md
+++ b/.claude/todos/issue-172-worker.md
@@ -1,0 +1,98 @@
+# Issue #172 Worker TODO
+
+対象コンポーネント: Text, Heading
+
+## 使用箇所一覧
+
+### Text（98箇所）
+- src/pages/profile.tsx (15箇所)
+- src/pages/reports.tsx (4箇所)
+- src/pages/settings.tsx (4箇所)
+- src/pages/login.tsx (1箇所)
+- src/pages/calendar.tsx (10箇所)
+- src/pages/index.tsx (14箇所)
+- src/pages/team.tsx (4箇所)
+- src/pages/tasks/[id]/edit.tsx (5箇所)
+- src/pages/tasks/new.tsx (1箇所)
+- src/pages/tasks/index.tsx (7箇所)
+- src/pages/projects/index.tsx (10箇所)
+- src/pages/projects/[id].tsx (18箇所)
+- src/pages/compare/Layout.tsx (2箇所)
+- src/components/layout/Sidebar.tsx (3箇所)
+- src/components/layout/Header.tsx (3箇所)
+- src/components/common/PageHeader.tsx (1箇所)
+- src/components/common/FilterBar.tsx (1箇所)
+- src/components/data/MemberCard.tsx (3箇所)
+- src/components/data/ProjectCard.tsx (4箇所)
+- src/components/data/TaskCard.tsx (4箇所)
+- src/components/ui/EmptyState.tsx (2箇所)
+- src/components/ui/ProgressBar.tsx (2箇所)
+- src/components/modal/ConfirmModal.tsx (1箇所)
+
+### Heading（18箇所）
+- src/pages/compare/Layout.tsx (2箇所)
+- src/pages/projects/[id].tsx (7箇所)
+- src/pages/projects/index.tsx (1箇所)
+- src/pages/login.tsx (1箇所)
+- src/pages/tasks/[id]/edit.tsx (2箇所)
+- src/pages/tasks/new.tsx (1箇所)
+- src/pages/tasks/index.tsx (1箇所)
+- src/pages/index.tsx (3箇所)
+- src/components/common/PageHeader.tsx (1箇所)
+
+## 使用されているprops
+
+### Text
+| prop | 使用例 |
+|------|--------|
+| fontSize | fontSize="3xl", fontSize="xl", fontSize="lg", fontSize="sm", fontSize="xs" |
+| fontWeight | fontWeight="bold", fontWeight="semibold", fontWeight="medium", fontWeight="normal" |
+| color | color="gray.600", color="gray.500", color="gray.400", color="gray.700", color="blue.600", color="green.600", color="red.500", color="primary.600" |
+| mb | mb={4}, mb={3}, mb={2}, mb={1} |
+| mt | mt={2}, mt={1} |
+| noOfLines | noOfLines={1}, noOfLines={2} |
+| textAlign | textAlign="center" |
+| maxW | maxW="md" |
+| minW | minW="200px" |
+| style | style={{ borderBottom: '...', letterSpacing: '...' }} |
+| （子要素のみ） | `<Text>テキスト内容</Text>` |
+
+### Heading
+| prop | 使用例 |
+|------|--------|
+| size | size="lg", size="md" |
+| mb | mb={8}, mb={4}, mb={2}, mb={0}（条件付き） |
+| color | color="primary.600", color="gray.600" |
+| （子要素のみ） | `<Heading>見出し内容</Heading>` |
+
+## 実装上の注意点
+
+### noOfLines対応
+- CSS Modulesで行数制限を実装する必要がある
+- `-webkit-line-clamp`を使用したテキスト省略を実装
+
+### fontSizeの対応
+- Chakra UIのfontSizeプリセット（3xl, xl, lg, sm, xs）をCSS変数またはクラスで対応
+
+### colorの対応
+- Chakra UIのカラーパレット（gray.600, primary.600など）をCSS変数で対応
+
+### Headingのsize対応
+- size="lg", size="md"などをフォントサイズとマージンに変換
+
+## タスク
+
+### コンポーネント作成
+1. [done] src/components/ui/Text.tsx を作成
+2. [done] src/components/ui/Text.module.css を作成
+3. [done] src/components/ui/Heading.tsx を作成
+4. [done] src/components/ui/Heading.module.css を作成
+
+### エクスポート追加
+5. [done] src/components/ui/index.ts にexport追加
+
+### 比較ページ作成
+6. [done] src/pages/compare/Text.tsx を作成（Chakra版と新版を並べて表示）
+
+### ビルド確認
+7. [done] npm run build でエラーがないことを確認

--- a/src/components/ui/Heading.module.css
+++ b/src/components/ui/Heading.module.css
@@ -6,33 +6,33 @@
 }
 
 .size4xl {
-  font-size: var(--font-size-4xl);
+  font-size: var(--heading-size-4xl);
 }
 
 .size3xl {
-  font-size: var(--font-size-3xl);
+  font-size: var(--heading-size-3xl);
 }
 
 .size2xl {
-  font-size: var(--font-size-2xl);
+  font-size: var(--heading-size-2xl);
 }
 
 .sizeXl {
-  font-size: var(--font-size-xl);
+  font-size: var(--heading-size-xl);
 }
 
 .sizeLg {
-  font-size: var(--font-size-lg);
+  font-size: var(--heading-size-lg);
 }
 
 .sizeMd {
-  font-size: var(--font-size-md);
+  font-size: var(--heading-size-md);
 }
 
 .sizeSm {
-  font-size: var(--font-size-sm);
+  font-size: var(--heading-size-sm);
 }
 
 .sizeXs {
-  font-size: var(--font-size-xs);
+  font-size: var(--heading-size-xs);
 }

--- a/src/components/ui/Heading.module.css
+++ b/src/components/ui/Heading.module.css
@@ -1,0 +1,38 @@
+.heading {
+  font-family: var(--font-family-heading);
+  font-weight: 700;
+  line-height: 1.2;
+  margin: 0;
+}
+
+.size4xl {
+  font-size: var(--font-size-4xl);
+}
+
+.size3xl {
+  font-size: var(--font-size-3xl);
+}
+
+.size2xl {
+  font-size: var(--font-size-2xl);
+}
+
+.sizeXl {
+  font-size: var(--font-size-xl);
+}
+
+.sizeLg {
+  font-size: var(--font-size-lg);
+}
+
+.sizeMd {
+  font-size: var(--font-size-md);
+}
+
+.sizeSm {
+  font-size: var(--font-size-sm);
+}
+
+.sizeXs {
+  font-size: var(--font-size-xs);
+}

--- a/src/components/ui/Heading.tsx
+++ b/src/components/ui/Heading.tsx
@@ -1,0 +1,75 @@
+import { forwardRef, HTMLAttributes, useMemo, createElement } from 'react';
+import styles from './Heading.module.css';
+import {
+  LayoutProps,
+  buildStyles,
+  extractLayoutProps,
+  mergeStyles,
+  applyCSSVars,
+  CSSPropertiesWithVars,
+} from './styleUtils';
+
+type HeadingSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl';
+type HeadingTag = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+
+export interface HeadingProps extends Omit<HTMLAttributes<HTMLHeadingElement>, 'color'>, Omit<LayoutProps, 'fontSize'> {
+  size?: HeadingSize;
+  as?: HeadingTag;
+}
+
+const sizeClassMap: Record<HeadingSize, string> = {
+  '4xl': styles.size4xl,
+  '3xl': styles.size3xl,
+  '2xl': styles.size2xl,
+  xl: styles.sizeXl,
+  lg: styles.sizeLg,
+  md: styles.sizeMd,
+  sm: styles.sizeSm,
+  xs: styles.sizeXs,
+};
+
+const sizeToTagMap: Record<HeadingSize, HeadingTag> = {
+  '4xl': 'h1',
+  '3xl': 'h2',
+  '2xl': 'h3',
+  xl: 'h4',
+  lg: 'h5',
+  md: 'h6',
+  sm: 'h6',
+  xs: 'h6',
+};
+
+const Heading = forwardRef<HTMLHeadingElement, HeadingProps>(
+  ({ className, style, children, size = 'xl', as, ...props }, ref) => {
+    const { layoutProps, rest } = extractLayoutProps(props);
+    const { style: computedStyle, cssVars } = buildStyles(layoutProps);
+
+    const combinedStyle = useMemo((): CSSPropertiesWithVars => {
+      const merged = mergeStyles(computedStyle, style);
+      return applyCSSVars(merged, cssVars);
+    }, [computedStyle, style, cssVars]);
+
+    const classNames = [styles.heading, sizeClassMap[size]];
+
+    if (className) {
+      classNames.push(className);
+    }
+
+    const tag = as || sizeToTagMap[size];
+
+    return createElement(
+      tag,
+      {
+        ref,
+        className: classNames.join(' '),
+        style: combinedStyle,
+        ...rest,
+      },
+      children
+    );
+  }
+);
+
+Heading.displayName = 'Heading';
+
+export default Heading;

--- a/src/components/ui/Text.module.css
+++ b/src/components/ui/Text.module.css
@@ -1,0 +1,27 @@
+.text {
+  font-family: var(--font-family-body);
+  line-height: 1.5;
+}
+
+.truncate {
+  display: -webkit-box;
+  -webkit-line-clamp: var(--lines);
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.fontWeightNormal {
+  font-weight: 400;
+}
+
+.fontWeightMedium {
+  font-weight: 500;
+}
+
+.fontWeightSemibold {
+  font-weight: 600;
+}
+
+.fontWeightBold {
+  font-weight: 700;
+}

--- a/src/components/ui/Text.tsx
+++ b/src/components/ui/Text.tsx
@@ -1,0 +1,72 @@
+import { forwardRef, HTMLAttributes, useMemo, CSSProperties } from 'react';
+import styles from './Text.module.css';
+import {
+  LayoutProps,
+  buildStyles,
+  extractLayoutProps,
+  mergeStyles,
+  applyCSSVars,
+  CSSPropertiesWithVars,
+} from './styleUtils';
+
+type FontSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl';
+type FontWeight = 'normal' | 'medium' | 'semibold' | 'bold';
+
+export interface TextProps extends Omit<HTMLAttributes<HTMLParagraphElement>, 'color'>, LayoutProps {
+  fontWeight?: FontWeight;
+  noOfLines?: number;
+}
+
+const fontWeightClassMap: Record<FontWeight, string> = {
+  normal: styles.fontWeightNormal,
+  medium: styles.fontWeightMedium,
+  semibold: styles.fontWeightSemibold,
+  bold: styles.fontWeightBold,
+};
+
+const Text = forwardRef<HTMLParagraphElement, TextProps>(
+  ({ className, style, children, fontWeight, noOfLines, ...props }, ref) => {
+    const { layoutProps, rest } = extractLayoutProps(props);
+    const { style: computedStyle, cssVars } = buildStyles(layoutProps);
+
+    const combinedStyle = useMemo((): CSSPropertiesWithVars => {
+      const merged = mergeStyles(computedStyle, style);
+      const withVars = applyCSSVars(merged, cssVars);
+
+      if (noOfLines !== undefined) {
+        withVars['--lines'] = String(noOfLines);
+      }
+
+      return withVars;
+    }, [computedStyle, style, cssVars, noOfLines]);
+
+    const classNames = [styles.text];
+
+    if (fontWeight) {
+      classNames.push(fontWeightClassMap[fontWeight]);
+    }
+
+    if (noOfLines !== undefined) {
+      classNames.push(styles.truncate);
+    }
+
+    if (className) {
+      classNames.push(className);
+    }
+
+    return (
+      <p
+        ref={ref}
+        className={classNames.join(' ')}
+        style={combinedStyle}
+        {...rest}
+      >
+        {children}
+      </p>
+    );
+  }
+);
+
+Text.displayName = 'Text';
+
+export default Text;

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -16,6 +16,9 @@ export { default as SimpleGrid } from './SimpleGrid';
 export { default as Wrap } from './Wrap';
 export { default as WrapItem } from './WrapItem';
 
+export { default as Text } from './Text';
+export { default as Heading } from './Heading';
+
 export type { ButtonVariant, ButtonSize } from './Button';
 export type { TaskStatus, ProjectStatus, UserStatus } from './StatusBadge';
 export type { Priority } from './PriorityBadge';
@@ -30,5 +33,8 @@ export type { CenterProps } from './Center';
 export type { SimpleGridProps } from './SimpleGrid';
 export type { WrapProps } from './Wrap';
 export type { WrapItemProps } from './WrapItem';
+
+export type { TextProps } from './Text';
+export type { HeadingProps } from './Heading';
 
 export type { LayoutProps, ResponsiveValue, SpacingValue, ColorValue, RadiusValue } from './styleUtils';

--- a/src/pages/compare/Text.tsx
+++ b/src/pages/compare/Text.tsx
@@ -1,0 +1,321 @@
+import {
+  Box as ChakraBox,
+  Text as ChakraText,
+  Heading as ChakraHeading,
+  SimpleGrid as ChakraSimpleGrid,
+  VStack as ChakraVStack,
+} from '@chakra-ui/react';
+import {
+  Box,
+  Text,
+  Heading,
+  VStack,
+} from '../../components/ui';
+
+const CompareSection = ({
+  title,
+  chakraVersion,
+  newVersion,
+}: {
+  title: string;
+  chakraVersion: React.ReactNode;
+  newVersion: React.ReactNode;
+}) => (
+  <ChakraBox mb={8}>
+    <ChakraHeading size="md" mb={4}>{title}</ChakraHeading>
+    <ChakraSimpleGrid columns={2} spacing={4}>
+      <ChakraBox>
+        <ChakraText fontWeight="bold" mb={2} color="blue.600">Chakra UI</ChakraText>
+        <ChakraBox border="1px" borderColor="gray.200" p={4} borderRadius="md">
+          {chakraVersion}
+        </ChakraBox>
+      </ChakraBox>
+      <ChakraBox>
+        <ChakraText fontWeight="bold" mb={2} color="green.600">New (CSS Modules)</ChakraText>
+        <ChakraBox border="1px" borderColor="gray.200" p={4} borderRadius="md">
+          {newVersion}
+        </ChakraBox>
+      </ChakraBox>
+    </ChakraSimpleGrid>
+  </ChakraBox>
+);
+
+const TextComparePage = () => {
+  return (
+    <ChakraBox p={8} maxW="1400px" mx="auto">
+      <ChakraHeading mb={8}>Text & Heading Components Comparison</ChakraHeading>
+
+      <ChakraHeading size="lg" mb={4}>Text Component</ChakraHeading>
+
+      <CompareSection
+        title="Text - Basic"
+        chakraVersion={
+          <ChakraText>This is a basic text</ChakraText>
+        }
+        newVersion={
+          <Text>This is a basic text</Text>
+        }
+      />
+
+      <CompareSection
+        title="Text - Font Sizes"
+        chakraVersion={
+          <ChakraVStack align="start" spacing={2}>
+            <ChakraText fontSize="xs">Font size xs (0.75rem)</ChakraText>
+            <ChakraText fontSize="sm">Font size sm (0.875rem)</ChakraText>
+            <ChakraText fontSize="md">Font size md (1rem)</ChakraText>
+            <ChakraText fontSize="lg">Font size lg (1.125rem)</ChakraText>
+            <ChakraText fontSize="xl">Font size xl (1.25rem)</ChakraText>
+            <ChakraText fontSize="2xl">Font size 2xl (1.5rem)</ChakraText>
+            <ChakraText fontSize="3xl">Font size 3xl (1.875rem)</ChakraText>
+            <ChakraText fontSize="4xl">Font size 4xl (2.25rem)</ChakraText>
+          </ChakraVStack>
+        }
+        newVersion={
+          <VStack align="start" spacing={2}>
+            <Text fontSize="xs">Font size xs (0.75rem)</Text>
+            <Text fontSize="sm">Font size sm (0.875rem)</Text>
+            <Text fontSize="md">Font size md (1rem)</Text>
+            <Text fontSize="lg">Font size lg (1.125rem)</Text>
+            <Text fontSize="xl">Font size xl (1.25rem)</Text>
+            <Text fontSize="2xl">Font size 2xl (1.5rem)</Text>
+            <Text fontSize="3xl">Font size 3xl (1.875rem)</Text>
+            <Text fontSize="4xl">Font size 4xl (2.25rem)</Text>
+          </VStack>
+        }
+      />
+
+      <CompareSection
+        title="Text - Font Weights"
+        chakraVersion={
+          <ChakraVStack align="start" spacing={2}>
+            <ChakraText fontWeight="normal">Normal weight (400)</ChakraText>
+            <ChakraText fontWeight="medium">Medium weight (500)</ChakraText>
+            <ChakraText fontWeight="semibold">Semibold weight (600)</ChakraText>
+            <ChakraText fontWeight="bold">Bold weight (700)</ChakraText>
+          </ChakraVStack>
+        }
+        newVersion={
+          <VStack align="start" spacing={2}>
+            <Text fontWeight="normal">Normal weight (400)</Text>
+            <Text fontWeight="medium">Medium weight (500)</Text>
+            <Text fontWeight="semibold">Semibold weight (600)</Text>
+            <Text fontWeight="bold">Bold weight (700)</Text>
+          </VStack>
+        }
+      />
+
+      <CompareSection
+        title="Text - Colors"
+        chakraVersion={
+          <ChakraVStack align="start" spacing={2}>
+            <ChakraText color="gray.600">Gray 600</ChakraText>
+            <ChakraText color="gray.500">Gray 500</ChakraText>
+            <ChakraText color="blue.600">Blue 600</ChakraText>
+            <ChakraText color="green.600">Green 600</ChakraText>
+            <ChakraText color="red.500">Red 500</ChakraText>
+            <ChakraText color="primary.600">Primary 600</ChakraText>
+          </ChakraVStack>
+        }
+        newVersion={
+          <VStack align="start" spacing={2}>
+            <Text color="gray.600">Gray 600</Text>
+            <Text color="gray.500">Gray 500</Text>
+            <Text color="blue.600">Blue 600</Text>
+            <Text color="green.600">Green 600</Text>
+            <Text color="red.500">Red 500</Text>
+            <Text color="primary.600">Primary 600</Text>
+          </VStack>
+        }
+      />
+
+      <CompareSection
+        title="Text - noOfLines (Text Truncation)"
+        chakraVersion={
+          <ChakraVStack align="start" spacing={4}>
+            <ChakraBox maxW="300px">
+              <ChakraText noOfLines={1}>
+                This is a very long text that should be truncated after one line because we set noOfLines to 1.
+              </ChakraText>
+            </ChakraBox>
+            <ChakraBox maxW="300px">
+              <ChakraText noOfLines={2}>
+                This is a very long text that should be truncated after two lines. It contains multiple sentences to demonstrate how the text truncation works with more content than can fit in the specified number of lines.
+              </ChakraText>
+            </ChakraBox>
+          </ChakraVStack>
+        }
+        newVersion={
+          <VStack align="start" spacing={4}>
+            <Box maxW="300px">
+              <Text noOfLines={1}>
+                This is a very long text that should be truncated after one line because we set noOfLines to 1.
+              </Text>
+            </Box>
+            <Box maxW="300px">
+              <Text noOfLines={2}>
+                This is a very long text that should be truncated after two lines. It contains multiple sentences to demonstrate how the text truncation works with more content than can fit in the specified number of lines.
+              </Text>
+            </Box>
+          </VStack>
+        }
+      />
+
+      <CompareSection
+        title="Text - Text Align"
+        chakraVersion={
+          <ChakraVStack align="stretch" spacing={2}>
+            <ChakraText textAlign="left">Left aligned text</ChakraText>
+            <ChakraText textAlign="center">Center aligned text</ChakraText>
+            <ChakraText textAlign="right">Right aligned text</ChakraText>
+          </ChakraVStack>
+        }
+        newVersion={
+          <VStack align="stretch" spacing={2}>
+            <Text textAlign="left">Left aligned text</Text>
+            <Text textAlign="center">Center aligned text</Text>
+            <Text textAlign="right">Right aligned text</Text>
+          </VStack>
+        }
+      />
+
+      <CompareSection
+        title="Text - With Margin"
+        chakraVersion={
+          <ChakraBox>
+            <ChakraText mb={4}>Text with margin bottom 4</ChakraText>
+            <ChakraText mt={2}>Text with margin top 2</ChakraText>
+          </ChakraBox>
+        }
+        newVersion={
+          <Box>
+            <Text mb={4}>Text with margin bottom 4</Text>
+            <Text mt={2}>Text with margin top 2</Text>
+          </Box>
+        }
+      />
+
+      <ChakraHeading size="lg" mb={4} mt={8}>Heading Component</ChakraHeading>
+
+      <CompareSection
+        title="Heading - Sizes"
+        chakraVersion={
+          <ChakraVStack align="start" spacing={2}>
+            <ChakraHeading size="4xl">Heading 4xl</ChakraHeading>
+            <ChakraHeading size="3xl">Heading 3xl</ChakraHeading>
+            <ChakraHeading size="2xl">Heading 2xl</ChakraHeading>
+            <ChakraHeading size="xl">Heading xl</ChakraHeading>
+            <ChakraHeading size="lg">Heading lg</ChakraHeading>
+            <ChakraHeading size="md">Heading md</ChakraHeading>
+            <ChakraHeading size="sm">Heading sm</ChakraHeading>
+            <ChakraHeading size="xs">Heading xs</ChakraHeading>
+          </ChakraVStack>
+        }
+        newVersion={
+          <VStack align="start" spacing={2}>
+            <Heading size="4xl">Heading 4xl</Heading>
+            <Heading size="3xl">Heading 3xl</Heading>
+            <Heading size="2xl">Heading 2xl</Heading>
+            <Heading size="xl">Heading xl</Heading>
+            <Heading size="lg">Heading lg</Heading>
+            <Heading size="md">Heading md</Heading>
+            <Heading size="sm">Heading sm</Heading>
+            <Heading size="xs">Heading xs</Heading>
+          </VStack>
+        }
+      />
+
+      <CompareSection
+        title="Heading - Colors"
+        chakraVersion={
+          <ChakraVStack align="start" spacing={2}>
+            <ChakraHeading size="lg" color="primary.600">Primary 600 Heading</ChakraHeading>
+            <ChakraHeading size="lg" color="gray.600">Gray 600 Heading</ChakraHeading>
+            <ChakraHeading size="lg" color="blue.600">Blue 600 Heading</ChakraHeading>
+          </ChakraVStack>
+        }
+        newVersion={
+          <VStack align="start" spacing={2}>
+            <Heading size="lg" color="primary.600">Primary 600 Heading</Heading>
+            <Heading size="lg" color="gray.600">Gray 600 Heading</Heading>
+            <Heading size="lg" color="blue.600">Blue 600 Heading</Heading>
+          </VStack>
+        }
+      />
+
+      <CompareSection
+        title="Heading - With Margin"
+        chakraVersion={
+          <ChakraBox>
+            <ChakraHeading size="lg" mb={4}>Heading with mb={4}</ChakraHeading>
+            <ChakraText>Some text below</ChakraText>
+            <ChakraHeading size="md" mb={2} mt={4}>Heading with mb={2} mt={4}</ChakraHeading>
+            <ChakraText>More text below</ChakraText>
+          </ChakraBox>
+        }
+        newVersion={
+          <Box>
+            <Heading size="lg" mb={4}>Heading with mb={4}</Heading>
+            <Text>Some text below</Text>
+            <Heading size="md" mb={2} mt={4}>Heading with mb={2} mt={4}</Heading>
+            <Text>More text below</Text>
+          </Box>
+        }
+      />
+
+      <CompareSection
+        title="Heading - Custom Tag (as prop)"
+        chakraVersion={
+          <ChakraVStack align="start" spacing={2}>
+            <ChakraHeading as="h1" size="lg">H1 element with size lg</ChakraHeading>
+            <ChakraHeading as="h2" size="md">H2 element with size md</ChakraHeading>
+            <ChakraHeading as="h3" size="sm">H3 element with size sm</ChakraHeading>
+          </ChakraVStack>
+        }
+        newVersion={
+          <VStack align="start" spacing={2}>
+            <Heading as="h1" size="lg">H1 element with size lg</Heading>
+            <Heading as="h2" size="md">H2 element with size md</Heading>
+            <Heading as="h3" size="sm">H3 element with size sm</Heading>
+          </VStack>
+        }
+      />
+
+      <CompareSection
+        title="Combined - Typical Page Layout"
+        chakraVersion={
+          <ChakraBox>
+            <ChakraHeading size="xl" mb={4}>Page Title</ChakraHeading>
+            <ChakraText fontSize="lg" color="gray.600" mb={6}>
+              This is a subtitle or description text that provides more context about the page.
+            </ChakraText>
+            <ChakraHeading size="md" mb={2}>Section Heading</ChakraHeading>
+            <ChakraText color="gray.700" mb={4}>
+              Regular paragraph text with default styling. This demonstrates how text components work together.
+            </ChakraText>
+            <ChakraText fontSize="sm" color="gray.500">
+              Small helper text or caption
+            </ChakraText>
+          </ChakraBox>
+        }
+        newVersion={
+          <Box>
+            <Heading size="xl" mb={4}>Page Title</Heading>
+            <Text fontSize="lg" color="gray.600" mb={6}>
+              This is a subtitle or description text that provides more context about the page.
+            </Text>
+            <Heading size="md" mb={2}>Section Heading</Heading>
+            <Text color="gray.700" mb={4}>
+              Regular paragraph text with default styling. This demonstrates how text components work together.
+            </Text>
+            <Text fontSize="sm" color="gray.500">
+              Small helper text or caption
+            </Text>
+          </Box>
+        }
+      />
+    </ChakraBox>
+  );
+};
+
+export default TextComparePage;

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -149,4 +149,16 @@
   --font-size-2xl: 1.5rem;
   --font-size-3xl: 1.875rem;
   --font-size-4xl: 2.25rem;
+  --font-size-5xl: 3rem;
+  --font-size-6xl: 3.75rem;
+  --font-size-7xl: 4.5rem;
+
+  --heading-size-4xl: 4.5rem;
+  --heading-size-3xl: 3.75rem;
+  --heading-size-2xl: 3rem;
+  --heading-size-xl: 2.25rem;
+  --heading-size-lg: 1.875rem;
+  --heading-size-md: 1.25rem;
+  --heading-size-sm: 1rem;
+  --heading-size-xs: 0.875rem;
 }


### PR DESCRIPTION
## Summary
- Text コンポーネント: fontSize, fontWeight, color, noOfLines（テキスト省略）対応
- Heading コンポーネント: size, as（h1-h6指定）対応
- 比較ページ /compare/Text を追加

## Test plan
- [ ] `npm run dev` でビルドエラーがないことを確認
- [ ] `/compare/Text` ページでChakra UIとCSS Modules版の表示が一致することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)