### PR TITLE
feat: フォーム基本コンポーネント追加 (#174)

### DIFF
--- a/.claude/todos/issue-174-reviewer.md
+++ b/.claude/todos/issue-174-reviewer.md
@@ -1,0 +1,90 @@
+# Issue #174 Reviewer TODO
+
+対象コンポーネント: Input, InputGroup, InputLeftElement, InputRightElement, Textarea, Select
+
+## レビュー観点
+
+### 1. Input機能の互換性
+- [ ] type属性が正しく動作する（text, email, tel, password, file, date, number）
+- [ ] placeholder, value, defaultValue が正しく動作する
+- [ ] onChange, onFocus, onBlur イベントが動作する
+- [ ] size（xs, sm, md, lg）が正しく反映される
+- [ ] variant（outline, filled, flushed, unstyled）が正しく反映される
+- [ ] bg="white" のスタイルが適用される
+- [ ] isDisabled, isInvalid, isReadOnly, isRequired 状態が動作する
+- [ ] focusBorderColor, errorBorderColor が適用される
+- [ ] forwardRefで参照が正しく転送される
+- [ ] react-hook-formのregisterと連携できる
+
+### 2. InputGroup機能の互換性
+- [ ] InputLeftElement/InputRightElementが正しく配置される
+- [ ] pointerEvents="none"でアイコンがクリックを通過させる
+- [ ] Inputのpaddingが適切に調整される
+- [ ] sizeがInput/Elementに伝播する
+- [ ] maxW, flex, minWなどのレイアウトpropsが動作する
+
+### 3. Textarea機能の互換性
+- [ ] rows属性が正しく動作する
+- [ ] resize属性が正しく動作する
+- [ ] placeholder, value, defaultValue が正しく動作する
+- [ ] size, variant が正しく反映される
+- [ ] forwardRefで参照が正しく転送される
+- [ ] react-hook-formのregisterと連携できる
+
+### 4. Select機能の互換性
+- [ ] placeholder（無効オプション）が表示される
+- [ ] optionの選択が正しく動作する
+- [ ] value, defaultValue が正しく動作する
+- [ ] size, variant が正しく反映される
+- [ ] maxWなどのレイアウトpropsが動作する
+- [ ] forwardRefで参照が正しく転送される
+- [ ] react-hook-formのregisterと連携できる
+
+### 5. Formコンポーネントラッパー
+- [ ] FormInputがCSS Modules版Inputを正しく使用
+- [ ] FormTextareaがCSS Modules版Textareaを正しく使用
+- [ ] FormSelectがCSS Modules版Selectを正しく使用
+- [ ] SearchInputがCSS Modules版InputGroupを正しく使用
+- [ ] label, error, helperText, isRequiredが正しく表示される
+- [ ] leftElement, rightElementが正しく配置される
+
+### 6. スタイルの一貫性
+- [ ] Chakra UI版と同等の見た目が再現されている
+- [ ] hover/focus/disabled状態のスタイルが適切
+- [ ] invalid状態の赤い境界線が表示される
+- [ ] カラーパレットがCSS変数で管理されている
+
+### 7. アクセシビリティ
+- [ ] キーボード操作が可能
+- [ ] フォーカス表示が適切
+- [ ] ラベルとの関連付けが正しい
+- [ ] エラーメッセージとaria-describedbyの関連付け
+
+### 8. 比較ページ
+- [ ] Before/Afterで視覚的な差異がない
+- [ ] すべてのvariant/sizeの組み合わせが確認できる
+- [ ] InputGroupの組み合わせが確認できる
+
+### 9. ビルド
+- [ ] TypeScriptエラーがない
+- [ ] npm run buildが成功する
+
+## スクリーンショット確認
+
+以下のページでBefore/Afterを比較:
+- /compare/Input
+- /projects（検索入力）
+- /tasks（検索入力、フィルターSelect）
+- /tasks/new（フォーム全体）
+- /tasks/[id]/edit（フォーム全体）
+- /profile（フォーム全体）
+- /settings（フォーム全体）
+- /team（検索入力、メンバー追加モーダル）
+- /projects/[id]（設定タブのフォーム）
+
+## 承認条件
+
+1. 上記すべてのチェック項目がパスしている
+2. Before/Afterスクリーンショットで視覚的な差異がない
+3. npm run buildが成功する
+4. 既存のFormコンポーネント（FormInput, FormTextarea, FormSelect, SearchInput）が正しく動作する

--- a/.claude/todos/issue-174-worker.md
+++ b/.claude/todos/issue-174-worker.md
@@ -1,0 +1,323 @@
+# Issue #174 Worker TODO
+
+対象コンポーネント: Input, InputGroup, InputLeftElement, InputRightElement, Textarea, Select
+
+## 使用箇所一覧
+
+### Input（30箇所以上）
+
+#### 専用フォームコンポーネント
+- src/components/form/FormInput.tsx
+  - L47: `<Input ref={ref} bg="white" {...props} />`
+  - L51: `<Input ref={ref} bg="white" {...props} />`
+  - InputPropsを拡張して使用
+
+- src/components/form/SearchInput.tsx
+  - L36-42: `<Input placeholder={placeholder} value={value} onChange={(e) => onChange(e.target.value)} bg="white" {...props} />`
+
+#### ページ
+- src/pages/projects/index.tsx
+  - L111-116: `<Input placeholder="プロジェクトを検索..." value={searchQuery} onChange={...} bg="white" />`
+
+- src/pages/tasks/index.tsx
+  - L158-163: `<Input placeholder="タスクを検索..." value={searchQuery} onChange={...} bg="white" />`
+
+- src/pages/profile.tsx
+  - L116-122: `<Input type="file" accept="image/*" onChange={handleImageUpload} display="none" id="avatar-upload" />`
+  - L156: `<Input {...register('name')} />`
+  - L161: `<Input {...register('email')} type="email" />`
+  - L166: `<Input {...register('phone')} type="tel" />`
+
+- src/pages/team.tsx
+  - L102-107: `<Input placeholder="メンバーを検索..." value={searchQuery} onChange={...} size="lg" />`
+  - L197: `<Input {...register('name')} placeholder="山田太郎" />`
+  - L201-205: `<Input {...register('email')} type="email" placeholder="yamada@example.com" />`
+  - L209: `<Input {...register('role')} placeholder="メンバー" />`
+
+- src/pages/settings.tsx
+  - L116-119: `<Input {...register('username')} defaultValue="山田太郎" />`
+  - L124-128: `<Input {...register('email')} type="email" defaultValue="yamada@example.com" />`
+  - L294: `<Input type="password" placeholder="現在のパスワード" />`
+  - L299: `<Input type="password" placeholder="新しいパスワード" />`
+  - L304: `<Input type="password" placeholder="パスワード確認" />`
+
+- src/pages/projects/[id].tsx
+  - L619: `<Input defaultValue={project.name} />`
+  - L630-634: `<Input type="date" defaultValue={...} />`
+  - L640-643: `<Input type="date" defaultValue={...} />`
+  - L660-665: `<Input type="number" min="0" max="100" defaultValue={project.progress} />`
+  - L671: `<Input defaultValue={project.tags.join(', ')} />`
+
+- src/pages/tasks/new.tsx
+  - L130-141: `<Input {...register('title', {...})} placeholder="例: トップページのUIデザイン作成" onFocus={...} onBlur={...} />`
+  - L274-281: `<Input type="date" {...register('dueDate', {...})} onFocus={...} onBlur={...} />`
+
+- src/pages/tasks/[id]/edit.tsx
+  - L239-250: `<Input {...register('title', {...})} placeholder="例: トップページのUIデザイン作成" onFocus={...} onBlur={...} />`
+  - L383-390: `<Input type="date" {...register('dueDate', {...})} onFocus={...} onBlur={...} />`
+
+### InputGroup（4箇所）
+
+- src/components/form/FormInput.tsx
+  - L43-49: `<InputGroup>` (InputLeftElement, Input, InputRightElementを包含)
+
+- src/components/form/SearchInput.tsx
+  - L32-54: `<InputGroup>` (InputLeftElement, Input, InputRightElementを包含)
+
+- src/pages/projects/index.tsx
+  - L107-117: `<InputGroup maxW="400px">` (InputLeftElement, Inputを包含)
+
+- src/pages/tasks/index.tsx
+  - L154-164: `<InputGroup maxW="400px" flex="1" minW="200px">` (InputLeftElement, Inputを包含)
+
+### InputLeftElement（4箇所）
+
+- src/components/form/FormInput.tsx
+  - L45: `<InputLeftElement pointerEvents="none">{leftElement}</InputLeftElement>`
+
+- src/components/form/SearchInput.tsx
+  - L33-35: `<InputLeftElement pointerEvents="none"><FiSearch color="gray" /></InputLeftElement>`
+
+- src/pages/projects/index.tsx
+  - L108-110: `<InputLeftElement pointerEvents="none"><FiSearch color="gray" /></InputLeftElement>`
+
+- src/pages/tasks/index.tsx
+  - L155-157: `<InputLeftElement pointerEvents="none"><FiSearch color="gray" /></InputLeftElement>`
+
+### InputRightElement（2箇所）
+
+- src/components/form/FormInput.tsx
+  - L48: `<InputRightElement>{rightElement}</InputRightElement>`
+
+- src/components/form/SearchInput.tsx
+  - L44-52: `<InputRightElement><IconButton ... /></InputRightElement>`
+
+### Textarea（5箇所）
+
+#### 専用フォームコンポーネント
+- src/components/form/FormTextarea.tsx
+  - L23: `<Textarea ref={ref} bg="white" {...props} />`
+  - TextareaPropsを拡張して使用
+
+#### ページ
+- src/pages/profile.tsx
+  - L171: `<Textarea {...register('bio')} rows={5} />`
+
+- src/pages/projects/[id].tsx
+  - L624: `<Textarea defaultValue={project.description} rows={4} />`
+
+- src/pages/tasks/new.tsx
+  - L154-166: `<Textarea {...register('description', {...})} placeholder="..." rows={5} onFocus={...} onBlur={...} />`
+
+- src/pages/tasks/[id]/edit.tsx
+  - L263-275: `<Textarea {...register('description', {...})} placeholder="..." rows={5} onFocus={...} onBlur={...} />`
+
+### Select（14箇所）
+
+#### 専用フォームコンポーネント
+- src/components/form/FormSelect.tsx
+  - L41: `<Select ref={ref} bg="white" placeholder={placeholder} {...props}>`
+  - SelectPropsを拡張して使用
+
+#### コンポーネント
+- src/components/common/FilterBar.tsx
+  - L58-71: `<Select value={...} onChange={...} bg="white" maxW={...} size="md">` (3箇所、フィルター用)
+
+#### ページ
+- src/pages/tasks/index.tsx
+  - L173-186: `<Select value={filterProject} onChange={...} bg="white" maxW="200px" size="md">`
+  - L188-199: `<Select value={filterStatus} onChange={...} bg="white" maxW="150px" size="md">`
+  - L201-213: `<Select value={filterPriority} onChange={...} bg="white" maxW="150px" size="md">`
+
+- src/pages/settings.tsx
+  - L133-137: `<Select {...register('language')} defaultValue="ja">`
+  - L142-155: `<Select {...register('timezone')} defaultValue="Asia/Tokyo">`
+  - L354-358: `<Select defaultValue="medium">` (フォントサイズ)
+
+- src/pages/projects/[id].tsx
+  - L650-655: `<Select defaultValue={project.status}>` (ステータス)
+
+- src/pages/tasks/new.tsx
+  - L179-191: `<Select {...register('projectId', {...})} placeholder="プロジェクトを選択" onFocus={...} onBlur={...}>`
+  - L205-217: `<Select {...register('assigneeId', {...})} placeholder="担当者を選択" onFocus={...} onBlur={...}>`
+  - L251-261: `<Select {...register('status', {...})} onFocus={...} onBlur={...}>`
+
+- src/pages/tasks/[id]/edit.tsx
+  - L288-301: `<Select {...register('projectId', {...})} placeholder="プロジェクトを選択" onFocus={...} onBlur={...}>`
+  - L314-325: `<Select {...register('assigneeId', {...})} placeholder="担当者を選択" onFocus={...} onBlur={...}>`
+  - L360-370: `<Select {...register('status', {...})} onFocus={...} onBlur={...}>`
+
+## 使用されているprops
+
+### Input
+| prop | 使用例 |
+|------|--------|
+| type | "text"(デフォルト), "email", "tel", "password", "file", "date", "number" |
+| placeholder | 検索やフォーム入力のヒント |
+| value | 制御コンポーネント用 |
+| onChange | イベントハンドラ |
+| defaultValue | 非制御コンポーネント用 |
+| bg | "white" |
+| size | "md"(デフォルト), "lg" |
+| display | "none"（ファイル入力の非表示用） |
+| id | "avatar-upload"（label連携用） |
+| accept | "image/*"（ファイル種類制限） |
+| min | "0"（数値入力） |
+| max | "100"（数値入力） |
+| onFocus | フォーカスイベント |
+| onBlur | ブラーイベント |
+| ref | forwardRefによる参照 |
+| {...register()} | react-hook-form連携 |
+
+### InputGroup
+| prop | 使用例 |
+|------|--------|
+| maxW | "400px" |
+| flex | "1" |
+| minW | "200px" |
+
+### InputLeftElement / InputRightElement
+| prop | 使用例 |
+|------|--------|
+| pointerEvents | "none" |
+| children | アイコンやボタン |
+
+### Textarea
+| prop | 使用例 |
+|------|--------|
+| placeholder | フォーム入力のヒント |
+| rows | {4}, {5} |
+| defaultValue | 非制御コンポーネント用 |
+| bg | "white" |
+| onFocus | フォーカスイベント |
+| onBlur | ブラーイベント |
+| ref | forwardRefによる参照 |
+| {...register()} | react-hook-form連携 |
+
+### Select
+| prop | 使用例 |
+|------|--------|
+| placeholder | "選択してください", "プロジェクトを選択" |
+| value | 制御コンポーネント用 |
+| onChange | イベントハンドラ |
+| defaultValue | "ja", "Asia/Tokyo", "medium" |
+| bg | "white" |
+| maxW | "200px", "150px" |
+| size | "md" |
+| onFocus | フォーカスイベント |
+| onBlur | ブラーイベント |
+| ref | forwardRefによる参照 |
+| {...register()} | react-hook-form連携 |
+| children | `<option>` 要素 |
+
+## Chakra UI API仕様（v2）
+
+### Input
+- variant: "outline" | "filled" | "flushed" | "unstyled"（デフォルト: "outline"）
+- size: "xs" | "sm" | "md" | "lg"（デフォルト: "md"）
+- isDisabled: boolean
+- isInvalid: boolean
+- isReadOnly: boolean
+- isRequired: boolean
+- focusBorderColor: string
+- errorBorderColor: string
+
+### InputGroup
+- size: "xs" | "sm" | "md" | "lg"
+- Inputのサイズと同期してInputLeftElement/InputRightElementのサイズも調整
+
+### InputLeftElement / InputRightElement
+- pointerEvents: "none" | "auto"（入力フィールドへのクリックを許可/禁止）
+- InputGroup内で使用し、Input内にアイコンや要素を配置
+
+### Textarea
+- variant: "outline" | "filled" | "flushed" | "unstyled"（デフォルト: "outline"）
+- size: "xs" | "sm" | "md" | "lg"（デフォルト: "md"）
+- resize: "none" | "both" | "horizontal" | "vertical"（デフォルト: "vertical"）
+- rows: number
+- isDisabled/isInvalid/isReadOnly/isRequired: boolean
+
+### Select
+- variant: "outline" | "filled" | "flushed" | "unstyled"（デフォルト: "outline"）
+- size: "xs" | "sm" | "md" | "lg"（デフォルト: "md"）
+- placeholder: string（最初の無効なオプションとして表示）
+- icon: ReactElement（ドロップダウンアイコンのカスタマイズ）
+- iconSize: string
+- isDisabled/isInvalid/isReadOnly/isRequired: boolean
+
+## 既存のFormコンポーネントラッパー
+
+### FormInput (src/components/form/FormInput.tsx)
+- InputをFormControlでラップ
+- label, error, helperText, isRequired, leftElement, rightElement を追加props
+- forwardRefで参照を転送
+
+### FormTextarea (src/components/form/FormTextarea.tsx)
+- TextareaをFormControlでラップ
+- label, error, helperText, isRequired を追加props
+- forwardRefで参照を転送
+
+### FormSelect (src/components/form/FormSelect.tsx)
+- SelectをFormControlでラップ
+- label, error, helperText, isRequired, options, placeholder を追加props
+- forwardRefで参照を転送
+
+### SearchInput (src/components/form/SearchInput.tsx)
+- InputGroup + InputLeftElement + Input + InputRightElement の組み合わせ
+- 検索アイコン、クリアボタン付き
+- value, onChange, onClear, showClearButton を追加props
+
+## 実装上の注意点
+
+### 共通
+- すべてのフォーム要素でreact-hook-formとの連携が必要
+- forwardRefパターンの維持が必須
+- bg="white" がほぼ全箇所で使用されている
+
+### InputGroup + Element
+- InputGroupはInputとElement群をグループ化するコンテナ
+- InputLeftElement/InputRightElementはabsolute positionで配置
+- pointerEvents="none"でアイコンがクリックを通過させる
+- InputのpaddingLeft/paddingRightを調整してElementとの重なりを防ぐ
+
+### Select
+- ネイティブの`<select>`要素をスタイリング
+- ブラウザのデフォルトドロップダウンUIを使用
+- placeholderは`<option disabled>`として実装
+
+### サイズバリエーション
+- xs, sm, md, lgのサイズに対応
+- InputGroupのsizeがInputとElementに伝播
+
+### バリアント
+- outline（デフォルト）: 境界線スタイル
+- filled: 背景色付き
+- flushed: 下線のみ
+- unstyled: スタイルなし
+
+## タスク
+
+### コンポーネント作成
+1. [ ] src/components/ui/Input.module.css を作成
+2. [ ] src/components/ui/Input.tsx を作成
+3. [ ] src/components/ui/InputGroup.module.css を作成
+4. [ ] src/components/ui/InputGroup.tsx を作成（InputLeftElement, InputRightElement含む）
+5. [ ] src/components/ui/Textarea.module.css を作成
+6. [ ] src/components/ui/Textarea.tsx を作成
+7. [ ] src/components/ui/Select.module.css を作成
+8. [ ] src/components/ui/Select.tsx を作成
+
+### Formコンポーネント更新
+9. [ ] src/components/form/FormInput.tsx をCSS Modules版Inputを使用するよう更新
+10. [ ] src/components/form/FormTextarea.tsx をCSS Modules版Textareaを使用するよう更新
+11. [ ] src/components/form/FormSelect.tsx をCSS Modules版Selectを使用するよう更新
+12. [ ] src/components/form/SearchInput.tsx をCSS Modules版InputGroupを使用するよう更新
+
+### エクスポート追加
+13. [ ] src/components/ui/index.ts にexport追加
+
+### 比較ページ作成
+14. [ ] src/pages/compare/Input.tsx を作成（Chakra版と新版を並べて表示）
+
+### ビルド確認
+15. [ ] npm run build でエラーがないことを確認

--- a/src/components/ui/Input.module.css
+++ b/src/components/ui/Input.module.css
@@ -1,0 +1,69 @@
+.input {
+  width: 100%;
+  font-family: var(--font-family-body);
+  line-height: 1.5;
+  border: 1px solid var(--color-gray-200);
+  border-radius: var(--radius-md);
+  background-color: var(--color-white);
+  color: var(--color-gray-800);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  outline: none;
+}
+
+.input::placeholder {
+  color: var(--color-gray-400);
+}
+
+.input:hover:not(:disabled):not(:focus) {
+  border-color: var(--color-gray-300);
+}
+
+.input:focus {
+  border-color: var(--color-blue-500);
+  box-shadow: 0 0 0 1px var(--color-blue-500);
+}
+
+.input:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  background-color: var(--color-gray-100);
+}
+
+.input:read-only {
+  background-color: var(--color-gray-50);
+}
+
+.input[aria-invalid="true"] {
+  border-color: var(--color-red-500);
+}
+
+.input[aria-invalid="true"]:focus {
+  border-color: var(--color-red-500);
+  box-shadow: 0 0 0 1px var(--color-red-500);
+}
+
+.sizeSm {
+  height: 32px;
+  padding: calc(var(--spacing) * 1) calc(var(--spacing) * 3);
+  font-size: var(--font-size-sm);
+}
+
+.sizeMd {
+  height: 40px;
+  padding: calc(var(--spacing) * 2) calc(var(--spacing) * 4);
+  font-size: var(--font-size-md);
+}
+
+.sizeLg {
+  height: 48px;
+  padding: calc(var(--spacing) * 3) calc(var(--spacing) * 4);
+  font-size: var(--font-size-lg);
+}
+
+.hasLeftElement {
+  padding-left: calc(var(--spacing) * 10);
+}
+
+.hasRightElement {
+  padding-right: calc(var(--spacing) * 10);
+}

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,0 +1,71 @@
+import { forwardRef, InputHTMLAttributes } from 'react';
+import styles from './Input.module.css';
+import { buildStyles, LayoutProps, extractLayoutProps, mergeStyles } from './styleUtils';
+
+export type InputSize = 'sm' | 'md' | 'lg';
+
+export interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size' | 'color'>, LayoutProps {
+  size?: InputSize;
+  isDisabled?: boolean;
+  isInvalid?: boolean;
+  isReadOnly?: boolean;
+  isRequired?: boolean;
+  hasLeftElement?: boolean;
+  hasRightElement?: boolean;
+}
+
+const sizeClassMap: Record<InputSize, string> = {
+  sm: styles.sizeSm,
+  md: styles.sizeMd,
+  lg: styles.sizeLg,
+};
+
+const Input = forwardRef<HTMLInputElement, InputProps>(
+  (
+    {
+      size = 'md',
+      isDisabled = false,
+      isInvalid = false,
+      isReadOnly = false,
+      isRequired = false,
+      hasLeftElement = false,
+      hasRightElement = false,
+      className,
+      style,
+      ...props
+    },
+    ref
+  ) => {
+    const { layoutProps, rest } = extractLayoutProps(props);
+    const { style: layoutStyle } = buildStyles(layoutProps);
+
+    const classNames = [
+      styles.input,
+      sizeClassMap[size],
+      hasLeftElement ? styles.hasLeftElement : undefined,
+      hasRightElement ? styles.hasRightElement : undefined,
+      className,
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    const mergedStyle = mergeStyles(layoutStyle, style);
+
+    return (
+      <input
+        ref={ref}
+        className={classNames}
+        style={mergedStyle}
+        disabled={isDisabled}
+        readOnly={isReadOnly}
+        required={isRequired}
+        aria-invalid={isInvalid || undefined}
+        {...rest}
+      />
+    );
+  }
+);
+
+Input.displayName = 'Input';
+
+export default Input;

--- a/src/components/ui/InputGroup.module.css
+++ b/src/components/ui/InputGroup.module.css
@@ -1,0 +1,5 @@
+.inputGroup {
+  position: relative;
+  display: flex;
+  width: 100%;
+}

--- a/src/components/ui/InputGroup.tsx
+++ b/src/components/ui/InputGroup.tsx
@@ -1,0 +1,72 @@
+import { forwardRef, HTMLAttributes, Children, isValidElement, cloneElement } from 'react';
+import styles from './InputGroup.module.css';
+import { buildStyles, LayoutProps, extractLayoutProps, mergeStyles } from './styleUtils';
+
+export interface InputGroupProps extends HTMLAttributes<HTMLDivElement>, LayoutProps {}
+
+interface ComponentWithDisplayName {
+  displayName?: string;
+}
+
+const hasDisplayName = (type: unknown): type is ComponentWithDisplayName => {
+  if (type === null || (typeof type !== 'function' && typeof type !== 'object')) {
+    return false;
+  }
+  return Object.prototype.hasOwnProperty.call(type, 'displayName');
+};
+
+const getDisplayName = (type: unknown): string | undefined => {
+  if (hasDisplayName(type)) {
+    return type.displayName;
+  }
+  return undefined;
+};
+
+const InputGroup = forwardRef<HTMLDivElement, InputGroupProps>(
+  ({ children, className, style, ...props }, ref) => {
+    const { layoutProps, rest } = extractLayoutProps(props);
+    const { style: layoutStyle } = buildStyles(layoutProps);
+
+    const classNames = [styles.inputGroup, className].filter(Boolean).join(' ');
+
+    const mergedStyle = mergeStyles(layoutStyle, style);
+
+    let hasLeftElement = false;
+    let hasRightElement = false;
+
+    Children.forEach(children, (child) => {
+      if (isValidElement(child)) {
+        const displayName = getDisplayName(child.type);
+        if (displayName === 'InputLeftElement') {
+          hasLeftElement = true;
+        }
+        if (displayName === 'InputRightElement') {
+          hasRightElement = true;
+        }
+      }
+    });
+
+    const enhancedChildren = Children.map(children, (child) => {
+      if (isValidElement<{ hasLeftElement?: boolean; hasRightElement?: boolean }>(child)) {
+        const displayName = getDisplayName(child.type);
+        if (displayName === 'Input') {
+          return cloneElement(child, {
+            hasLeftElement,
+            hasRightElement,
+          });
+        }
+      }
+      return child;
+    });
+
+    return (
+      <div ref={ref} className={classNames} style={mergedStyle} {...rest}>
+        {enhancedChildren}
+      </div>
+    );
+  }
+);
+
+InputGroup.displayName = 'InputGroup';
+
+export default InputGroup;

--- a/src/components/ui/InputLeftElement.module.css
+++ b/src/components/ui/InputLeftElement.module.css
@@ -1,0 +1,16 @@
+.inputLeftElement {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: calc(var(--spacing) * 10);
+  color: var(--color-gray-500);
+  z-index: 1;
+}
+
+.pointerEventsNone {
+  pointer-events: none;
+}

--- a/src/components/ui/InputLeftElement.tsx
+++ b/src/components/ui/InputLeftElement.tsx
@@ -1,0 +1,29 @@
+import { forwardRef, HTMLAttributes, ReactNode } from 'react';
+import styles from './InputLeftElement.module.css';
+
+export interface InputLeftElementProps extends HTMLAttributes<HTMLDivElement> {
+  pointerEvents?: 'none' | 'auto';
+  children?: ReactNode;
+}
+
+const InputLeftElement = forwardRef<HTMLDivElement, InputLeftElementProps>(
+  ({ pointerEvents = 'auto', children, className, ...props }, ref) => {
+    const classNames = [
+      styles.inputLeftElement,
+      pointerEvents === 'none' ? styles.pointerEventsNone : undefined,
+      className,
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    return (
+      <div ref={ref} className={classNames} {...props}>
+        {children}
+      </div>
+    );
+  }
+);
+
+InputLeftElement.displayName = 'InputLeftElement';
+
+export default InputLeftElement;

--- a/src/components/ui/InputRightElement.module.css
+++ b/src/components/ui/InputRightElement.module.css
@@ -1,0 +1,16 @@
+.inputRightElement {
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: calc(var(--spacing) * 10);
+  color: var(--color-gray-500);
+  z-index: 1;
+}
+
+.pointerEventsNone {
+  pointer-events: none;
+}

--- a/src/components/ui/InputRightElement.tsx
+++ b/src/components/ui/InputRightElement.tsx
@@ -1,0 +1,29 @@
+import { forwardRef, HTMLAttributes, ReactNode } from 'react';
+import styles from './InputRightElement.module.css';
+
+export interface InputRightElementProps extends HTMLAttributes<HTMLDivElement> {
+  pointerEvents?: 'none' | 'auto';
+  children?: ReactNode;
+}
+
+const InputRightElement = forwardRef<HTMLDivElement, InputRightElementProps>(
+  ({ pointerEvents = 'auto', children, className, ...props }, ref) => {
+    const classNames = [
+      styles.inputRightElement,
+      pointerEvents === 'none' ? styles.pointerEventsNone : undefined,
+      className,
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    return (
+      <div ref={ref} className={classNames} {...props}>
+        {children}
+      </div>
+    );
+  }
+);
+
+InputRightElement.displayName = 'InputRightElement';
+
+export default InputRightElement;

--- a/src/components/ui/Select.module.css
+++ b/src/components/ui/Select.module.css
@@ -1,0 +1,62 @@
+.select {
+  width: 100%;
+  font-family: var(--font-family-body);
+  line-height: 1.5;
+  border: 1px solid var(--color-gray-200);
+  border-radius: var(--radius-md);
+  background-color: var(--color-white);
+  color: var(--color-gray-800);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  outline: none;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23718096' d='M3 4.5L6 7.5L9 4.5'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  padding-right: calc(var(--spacing) * 8);
+  cursor: pointer;
+}
+
+.select:hover:not(:disabled):not(:focus) {
+  border-color: var(--color-gray-300);
+}
+
+.select:focus {
+  border-color: var(--color-blue-500);
+  box-shadow: 0 0 0 1px var(--color-blue-500);
+}
+
+.select:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  background-color: var(--color-gray-100);
+}
+
+.select[aria-invalid="true"] {
+  border-color: var(--color-red-500);
+}
+
+.select[aria-invalid="true"]:focus {
+  border-color: var(--color-red-500);
+  box-shadow: 0 0 0 1px var(--color-red-500);
+}
+
+.sizeSm {
+  height: 32px;
+  padding: calc(var(--spacing) * 1) calc(var(--spacing) * 3);
+  padding-right: calc(var(--spacing) * 8);
+  font-size: var(--font-size-sm);
+}
+
+.sizeMd {
+  height: 40px;
+  padding: calc(var(--spacing) * 2) calc(var(--spacing) * 4);
+  padding-right: calc(var(--spacing) * 8);
+  font-size: var(--font-size-md);
+}
+
+.sizeLg {
+  height: 48px;
+  padding: calc(var(--spacing) * 3) calc(var(--spacing) * 4);
+  padding-right: calc(var(--spacing) * 8);
+  font-size: var(--font-size-lg);
+}

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -1,0 +1,71 @@
+import { forwardRef, SelectHTMLAttributes, ReactNode } from 'react';
+import styles from './Select.module.css';
+import { buildStyles, LayoutProps, extractLayoutProps, mergeStyles } from './styleUtils';
+
+export type SelectSize = 'sm' | 'md' | 'lg';
+
+export interface SelectProps extends Omit<SelectHTMLAttributes<HTMLSelectElement>, 'size' | 'color'>, LayoutProps {
+  size?: SelectSize;
+  placeholder?: string;
+  isDisabled?: boolean;
+  isInvalid?: boolean;
+  isReadOnly?: boolean;
+  isRequired?: boolean;
+  children?: ReactNode;
+}
+
+const sizeClassMap: Record<SelectSize, string> = {
+  sm: styles.sizeSm,
+  md: styles.sizeMd,
+  lg: styles.sizeLg,
+};
+
+const Select = forwardRef<HTMLSelectElement, SelectProps>(
+  (
+    {
+      size = 'md',
+      placeholder,
+      isDisabled = false,
+      isInvalid = false,
+      isReadOnly = false,
+      isRequired = false,
+      children,
+      className,
+      style,
+      ...props
+    },
+    ref
+  ) => {
+    const { layoutProps, rest } = extractLayoutProps(props);
+    const { style: layoutStyle } = buildStyles(layoutProps);
+
+    const classNames = [styles.select, sizeClassMap[size], className]
+      .filter(Boolean)
+      .join(' ');
+
+    const mergedStyle = mergeStyles(layoutStyle, style);
+
+    return (
+      <select
+        ref={ref}
+        className={classNames}
+        style={mergedStyle}
+        disabled={isDisabled || isReadOnly}
+        required={isRequired}
+        aria-invalid={isInvalid || undefined}
+        {...rest}
+      >
+        {placeholder && (
+          <option value="" disabled>
+            {placeholder}
+          </option>
+        )}
+        {children}
+      </select>
+    );
+  }
+);
+
+Select.displayName = 'Select';
+
+export default Select;

--- a/src/components/ui/Textarea.module.css
+++ b/src/components/ui/Textarea.module.css
@@ -1,0 +1,47 @@
+.textarea {
+  width: 100%;
+  font-family: var(--font-family-body);
+  font-size: var(--font-size-md);
+  line-height: 1.5;
+  border: 1px solid var(--color-gray-200);
+  border-radius: var(--radius-md);
+  background-color: var(--color-white);
+  color: var(--color-gray-800);
+  padding: calc(var(--spacing) * 2) calc(var(--spacing) * 4);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  outline: none;
+  resize: vertical;
+  min-height: 80px;
+}
+
+.textarea::placeholder {
+  color: var(--color-gray-400);
+}
+
+.textarea:hover:not(:disabled):not(:focus) {
+  border-color: var(--color-gray-300);
+}
+
+.textarea:focus {
+  border-color: var(--color-blue-500);
+  box-shadow: 0 0 0 1px var(--color-blue-500);
+}
+
+.textarea:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  background-color: var(--color-gray-100);
+}
+
+.textarea:read-only {
+  background-color: var(--color-gray-50);
+}
+
+.textarea[aria-invalid="true"] {
+  border-color: var(--color-red-500);
+}
+
+.textarea[aria-invalid="true"]:focus {
+  border-color: var(--color-red-500);
+  box-shadow: 0 0 0 1px var(--color-red-500);
+}

--- a/src/components/ui/Textarea.tsx
+++ b/src/components/ui/Textarea.tsx
@@ -1,0 +1,49 @@
+import { forwardRef, TextareaHTMLAttributes } from 'react';
+import styles from './Textarea.module.css';
+import { buildStyles, LayoutProps, extractLayoutProps, mergeStyles } from './styleUtils';
+
+export interface TextareaProps extends Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, 'color'>, LayoutProps {
+  isDisabled?: boolean;
+  isInvalid?: boolean;
+  isReadOnly?: boolean;
+  isRequired?: boolean;
+}
+
+const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
+  (
+    {
+      isDisabled = false,
+      isInvalid = false,
+      isReadOnly = false,
+      isRequired = false,
+      className,
+      style,
+      ...props
+    },
+    ref
+  ) => {
+    const { layoutProps, rest } = extractLayoutProps(props);
+    const { style: layoutStyle } = buildStyles(layoutProps);
+
+    const classNames = [styles.textarea, className].filter(Boolean).join(' ');
+
+    const mergedStyle = mergeStyles(layoutStyle, style);
+
+    return (
+      <textarea
+        ref={ref}
+        className={classNames}
+        style={mergedStyle}
+        disabled={isDisabled}
+        readOnly={isReadOnly}
+        required={isRequired}
+        aria-invalid={isInvalid || undefined}
+        {...rest}
+      />
+    );
+  }
+);
+
+Textarea.displayName = 'Textarea';
+
+export default Textarea;

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -8,6 +8,13 @@ export { default as StatusBadge } from './StatusBadge';
 export { default as PriorityBadge } from './PriorityBadge';
 export { default as RoleBadge } from './RoleBadge';
 
+export { default as Input } from './Input';
+export { default as InputGroup } from './InputGroup';
+export { default as InputLeftElement } from './InputLeftElement';
+export { default as InputRightElement } from './InputRightElement';
+export { default as Textarea } from './Textarea';
+export { default as Select } from './Select';
+
 export { default as Box } from './Box';
 export { default as Flex } from './Flex';
 export { default as VStack } from './VStack';
@@ -40,5 +47,12 @@ export type { WrapItemProps } from './WrapItem';
 
 export type { TextProps } from './Text';
 export type { HeadingProps } from './Heading';
+
+export type { InputSize, InputProps } from './Input';
+export type { InputGroupProps } from './InputGroup';
+export type { InputLeftElementProps } from './InputLeftElement';
+export type { InputRightElementProps } from './InputRightElement';
+export type { TextareaProps } from './Textarea';
+export type { SelectSize, SelectProps } from './Select';
 
 export type { LayoutProps, ResponsiveValue, SpacingValue, ColorValue, RadiusValue } from './styleUtils';

--- a/src/pages/compare/Form.tsx
+++ b/src/pages/compare/Form.tsx
@@ -1,0 +1,365 @@
+import {
+  Box as ChakraBox,
+  Input as ChakraInput,
+  InputGroup as ChakraInputGroup,
+  InputLeftElement as ChakraInputLeftElement,
+  InputRightElement as ChakraInputRightElement,
+  Textarea as ChakraTextarea,
+  Select as ChakraSelect,
+  SimpleGrid as ChakraSimpleGrid,
+  Text,
+  Heading,
+  HStack as ChakraHStack,
+  VStack as ChakraVStack,
+} from '@chakra-ui/react';
+import { FiSearch, FiMail, FiLock, FiX } from 'react-icons/fi';
+import {
+  Input,
+  InputGroup,
+  InputLeftElement,
+  InputRightElement,
+  Textarea,
+  Select,
+  Box,
+  HStack,
+  VStack,
+  IconButton,
+} from '../../components/ui';
+
+const CompareSection = ({
+  title,
+  chakraVersion,
+  newVersion,
+}: {
+  title: string;
+  chakraVersion: React.ReactNode;
+  newVersion: React.ReactNode;
+}) => (
+  <ChakraBox mb={8}>
+    <Heading size="md" mb={4}>{title}</Heading>
+    <ChakraSimpleGrid columns={2} spacing={4}>
+      <ChakraBox>
+        <Text fontWeight="bold" mb={2} color="blue.600">Chakra UI</Text>
+        <ChakraBox border="1px" borderColor="gray.200" p={4} borderRadius="md">
+          {chakraVersion}
+        </ChakraBox>
+      </ChakraBox>
+      <ChakraBox>
+        <Text fontWeight="bold" mb={2} color="green.600">New (CSS Modules)</Text>
+        <ChakraBox border="1px" borderColor="gray.200" p={4} borderRadius="md">
+          {newVersion}
+        </ChakraBox>
+      </ChakraBox>
+    </ChakraSimpleGrid>
+  </ChakraBox>
+);
+
+const FormComparePage = () => {
+  return (
+    <ChakraBox p={8} maxW="1400px" mx="auto">
+      <Heading mb={8}>Form Components Comparison</Heading>
+
+      <CompareSection
+        title="Input - Basic"
+        chakraVersion={
+          <ChakraVStack spacing={4} align="stretch">
+            <ChakraInput placeholder="Default input" />
+            <ChakraInput placeholder="With value" defaultValue="Hello World" />
+          </ChakraVStack>
+        }
+        newVersion={
+          <VStack spacing={4} align="stretch">
+            <Input placeholder="Default input" />
+            <Input placeholder="With value" defaultValue="Hello World" />
+          </VStack>
+        }
+      />
+
+      <CompareSection
+        title="Input - Types"
+        chakraVersion={
+          <ChakraVStack spacing={4} align="stretch">
+            <ChakraInput type="text" placeholder="Text input" />
+            <ChakraInput type="email" placeholder="Email input" />
+            <ChakraInput type="password" placeholder="Password input" />
+            <ChakraInput type="number" placeholder="Number input" />
+            <ChakraInput type="date" />
+          </ChakraVStack>
+        }
+        newVersion={
+          <VStack spacing={4} align="stretch">
+            <Input type="text" placeholder="Text input" />
+            <Input type="email" placeholder="Email input" />
+            <Input type="password" placeholder="Password input" />
+            <Input type="number" placeholder="Number input" />
+            <Input type="date" />
+          </VStack>
+        }
+      />
+
+      <CompareSection
+        title="Input - Sizes"
+        chakraVersion={
+          <ChakraVStack spacing={4} align="stretch">
+            <ChakraInput size="sm" placeholder="Small" />
+            <ChakraInput size="md" placeholder="Medium" />
+            <ChakraInput size="lg" placeholder="Large" />
+          </ChakraVStack>
+        }
+        newVersion={
+          <VStack spacing={4} align="stretch">
+            <Input size="sm" placeholder="Small" />
+            <Input size="md" placeholder="Medium" />
+            <Input size="lg" placeholder="Large" />
+          </VStack>
+        }
+      />
+
+      <CompareSection
+        title="Input - States"
+        chakraVersion={
+          <ChakraVStack spacing={4} align="stretch">
+            <ChakraInput placeholder="Normal" />
+            <ChakraInput placeholder="Disabled" isDisabled />
+            <ChakraInput placeholder="Read only" isReadOnly defaultValue="Read only value" />
+            <ChakraInput placeholder="Invalid" isInvalid />
+          </ChakraVStack>
+        }
+        newVersion={
+          <VStack spacing={4} align="stretch">
+            <Input placeholder="Normal" />
+            <Input placeholder="Disabled" isDisabled />
+            <Input placeholder="Read only" isReadOnly defaultValue="Read only value" />
+            <Input placeholder="Invalid" isInvalid />
+          </VStack>
+        }
+      />
+
+      <CompareSection
+        title="InputGroup with InputLeftElement"
+        chakraVersion={
+          <ChakraVStack spacing={4} align="stretch">
+            <ChakraInputGroup>
+              <ChakraInputLeftElement pointerEvents="none">
+                <FiSearch color="gray" />
+              </ChakraInputLeftElement>
+              <ChakraInput placeholder="Search..." />
+            </ChakraInputGroup>
+            <ChakraInputGroup>
+              <ChakraInputLeftElement pointerEvents="none">
+                <FiMail color="gray" />
+              </ChakraInputLeftElement>
+              <ChakraInput type="email" placeholder="Email address" />
+            </ChakraInputGroup>
+          </ChakraVStack>
+        }
+        newVersion={
+          <VStack spacing={4} align="stretch">
+            <InputGroup>
+              <InputLeftElement pointerEvents="none">
+                <FiSearch color="gray" />
+              </InputLeftElement>
+              <Input placeholder="Search..." />
+            </InputGroup>
+            <InputGroup>
+              <InputLeftElement pointerEvents="none">
+                <FiMail color="gray" />
+              </InputLeftElement>
+              <Input type="email" placeholder="Email address" />
+            </InputGroup>
+          </VStack>
+        }
+      />
+
+      <CompareSection
+        title="InputGroup with InputRightElement"
+        chakraVersion={
+          <ChakraVStack spacing={4} align="stretch">
+            <ChakraInputGroup>
+              <ChakraInput placeholder="Search..." />
+              <ChakraInputRightElement>
+                <FiX color="gray" />
+              </ChakraInputRightElement>
+            </ChakraInputGroup>
+            <ChakraInputGroup>
+              <ChakraInputLeftElement pointerEvents="none">
+                <FiLock color="gray" />
+              </ChakraInputLeftElement>
+              <ChakraInput type="password" placeholder="Password" />
+              <ChakraInputRightElement>
+                <FiX color="gray" />
+              </ChakraInputRightElement>
+            </ChakraInputGroup>
+          </ChakraVStack>
+        }
+        newVersion={
+          <VStack spacing={4} align="stretch">
+            <InputGroup>
+              <Input placeholder="Search..." />
+              <InputRightElement>
+                <FiX color="gray" />
+              </InputRightElement>
+            </InputGroup>
+            <InputGroup>
+              <InputLeftElement pointerEvents="none">
+                <FiLock color="gray" />
+              </InputLeftElement>
+              <Input type="password" placeholder="Password" />
+              <InputRightElement>
+                <FiX color="gray" />
+              </InputRightElement>
+            </InputGroup>
+          </VStack>
+        }
+      />
+
+      <CompareSection
+        title="Textarea - Basic"
+        chakraVersion={
+          <ChakraVStack spacing={4} align="stretch">
+            <ChakraTextarea placeholder="Enter description..." />
+            <ChakraTextarea placeholder="With rows" rows={5} />
+            <ChakraTextarea placeholder="With default value" defaultValue="Lorem ipsum dolor sit amet" />
+          </ChakraVStack>
+        }
+        newVersion={
+          <VStack spacing={4} align="stretch">
+            <Textarea placeholder="Enter description..." />
+            <Textarea placeholder="With rows" rows={5} />
+            <Textarea placeholder="With default value" defaultValue="Lorem ipsum dolor sit amet" />
+          </VStack>
+        }
+      />
+
+      <CompareSection
+        title="Textarea - States"
+        chakraVersion={
+          <ChakraVStack spacing={4} align="stretch">
+            <ChakraTextarea placeholder="Normal" />
+            <ChakraTextarea placeholder="Disabled" isDisabled />
+            <ChakraTextarea placeholder="Read only" isReadOnly defaultValue="Read only content" />
+            <ChakraTextarea placeholder="Invalid" isInvalid />
+          </ChakraVStack>
+        }
+        newVersion={
+          <VStack spacing={4} align="stretch">
+            <Textarea placeholder="Normal" />
+            <Textarea placeholder="Disabled" isDisabled />
+            <Textarea placeholder="Read only" isReadOnly defaultValue="Read only content" />
+            <Textarea placeholder="Invalid" isInvalid />
+          </VStack>
+        }
+      />
+
+      <CompareSection
+        title="Select - Basic"
+        chakraVersion={
+          <ChakraVStack spacing={4} align="stretch">
+            <ChakraSelect placeholder="Select option">
+              <option value="option1">Option 1</option>
+              <option value="option2">Option 2</option>
+              <option value="option3">Option 3</option>
+            </ChakraSelect>
+            <ChakraSelect defaultValue="option2">
+              <option value="option1">Option 1</option>
+              <option value="option2">Option 2</option>
+              <option value="option3">Option 3</option>
+            </ChakraSelect>
+          </ChakraVStack>
+        }
+        newVersion={
+          <VStack spacing={4} align="stretch">
+            <Select placeholder="Select option">
+              <option value="option1">Option 1</option>
+              <option value="option2">Option 2</option>
+              <option value="option3">Option 3</option>
+            </Select>
+            <Select defaultValue="option2">
+              <option value="option1">Option 1</option>
+              <option value="option2">Option 2</option>
+              <option value="option3">Option 3</option>
+            </Select>
+          </VStack>
+        }
+      />
+
+      <CompareSection
+        title="Select - Sizes"
+        chakraVersion={
+          <ChakraVStack spacing={4} align="stretch">
+            <ChakraSelect size="sm" placeholder="Small">
+              <option value="option1">Option 1</option>
+            </ChakraSelect>
+            <ChakraSelect size="md" placeholder="Medium">
+              <option value="option1">Option 1</option>
+            </ChakraSelect>
+            <ChakraSelect size="lg" placeholder="Large">
+              <option value="option1">Option 1</option>
+            </ChakraSelect>
+          </ChakraVStack>
+        }
+        newVersion={
+          <VStack spacing={4} align="stretch">
+            <Select size="sm" placeholder="Small">
+              <option value="option1">Option 1</option>
+            </Select>
+            <Select size="md" placeholder="Medium">
+              <option value="option1">Option 1</option>
+            </Select>
+            <Select size="lg" placeholder="Large">
+              <option value="option1">Option 1</option>
+            </Select>
+          </VStack>
+        }
+      />
+
+      <CompareSection
+        title="Select - States"
+        chakraVersion={
+          <ChakraVStack spacing={4} align="stretch">
+            <ChakraSelect placeholder="Normal">
+              <option value="option1">Option 1</option>
+            </ChakraSelect>
+            <ChakraSelect placeholder="Disabled" isDisabled>
+              <option value="option1">Option 1</option>
+            </ChakraSelect>
+            <ChakraSelect placeholder="Invalid" isInvalid>
+              <option value="option1">Option 1</option>
+            </ChakraSelect>
+          </ChakraVStack>
+        }
+        newVersion={
+          <VStack spacing={4} align="stretch">
+            <Select placeholder="Normal">
+              <option value="option1">Option 1</option>
+            </Select>
+            <Select placeholder="Disabled" isDisabled>
+              <option value="option1">Option 1</option>
+            </Select>
+            <Select placeholder="Invalid" isInvalid>
+              <option value="option1">Option 1</option>
+            </Select>
+          </VStack>
+        }
+      />
+
+      <CompareSection
+        title="Input with bg prop"
+        chakraVersion={
+          <ChakraVStack spacing={4} align="stretch">
+            <ChakraInput placeholder="Default" />
+            <ChakraInput placeholder="White background" bg="white" />
+          </ChakraVStack>
+        }
+        newVersion={
+          <VStack spacing={4} align="stretch">
+            <Input placeholder="Default" />
+            <Input placeholder="White background" bg="white" />
+          </VStack>
+        }
+      />
+    </ChakraBox>
+  );
+};
+
+export default FormComparePage;


### PR DESCRIPTION
## Summary
- Input コンポーネント: type, size, placeholder, isDisabled, isInvalid, isReadOnly対応
- InputGroup コンポーネント: InputLeftElement, InputRightElementのグループ化
- InputLeftElement / InputRightElement コンポーネント: pointerEvents対応
- Textarea コンポーネント: rows, placeholder対応
- Select コンポーネント: placeholder, size対応
- 比較ページ /compare/Form を追加

## Test plan
- [ ] `npm run dev` でビルドエラーがないことを確認
- [ ] `/compare/Form` ページでChakra UIとCSS Modules版の表示が一致することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)