### PR TITLE
feat: Avatarコンポーネント追加 (Avatar, AvatarGroup, AvatarBadge)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -3,7 +3,8 @@
     "allow": [
       "Bash(git add:*)",
       "Bash(git commit -m \"$\\(cat <<''EOF''\nfix: VStackのデフォルトalignをstretchに修正、色のCSS変数追加\n\n- VStackのデフォルトalignをcenterからstretchに変更（Chakra UI互換）\n- purple, orange, teal, cyan, pinkの色変数を追加\n\nCo-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>\nEOF\n\\)\")",
-      "Bash(git push)"
+      "Bash(git push)",
+      "Bash(agent-browser:*)"
     ]
   }
 }

--- a/.claude/todos/issue-177-reviewer.md
+++ b/.claude/todos/issue-177-reviewer.md
@@ -1,0 +1,50 @@
+# Issue #177 Reviewer TODO
+
+## 対象コンポーネント
+Avatar, AvatarGroup, AvatarBadge
+
+## レビュー観点
+
+### 型定義
+- [ ] AvatarProps が適切に定義されているか
+- [ ] size が "2xs" | "xs" | "sm" | "md" | "lg" | "xl" | "2xl" をサポートしているか
+- [ ] AvatarGroupProps に max, spacing, size が含まれているか
+- [ ] AvatarBadgeProps に boxSize, bg, border 等のスタイルpropsが含まれているか
+- [ ] forwardRef が正しく実装されているか（motion対応のため）
+
+### スタイル
+- [ ] 各サイズのピクセル値が適切か
+- [ ] イニシャル表示時のフォントサイズがサイズに応じて調整されているか
+- [ ] AvatarGroup のスタッキング（負のマージン）が正しく動作するか
+- [ ] AvatarBadge の配置が正しいか（右下）
+- [ ] フォールバック背景色が `name` から一貫して生成されるか
+
+### 機能
+- [ ] 画像の読み込み失敗時にイニシャルまたはデフォルトアイコンが表示されるか
+- [ ] AvatarGroup の max prop が正しく動作するか（+X表示）
+- [ ] AvatarBadge が Avatar 内で正しく配置されるか
+
+### アクセシビリティ
+- [ ] 画像に適切な alt 属性が設定されているか（name を使用）
+- [ ] role="img" が設定されているか
+
+## タスク
+1. [pending] コードレビュー（型定義、props、スタイル）
+2. [pending] /compare/Avatar ページで動作確認
+3. [pending] スクリーンショット取得
+4. [pending] 問題があれば修正
+
+## 確認ページ
+- `/compare/Avatar` - Chakra版と新版の比較
+
+## 確認すべき使用箇所
+- `/profile` - size="2xl"、motion対応
+- `/projects` - AvatarGroup with max
+- `/team` - size="xl"
+- `/` (ダッシュボード) - size="xs"
+
+## スクリーンショット
+```bash
+agent-browser --cdp 9222 open "http://localhost:3000/compare/Avatar"
+agent-browser --cdp 9222 screenshot "screenshots/issue-177/compare-avatar.png" --full
+```

--- a/.claude/todos/issue-177-worker.md
+++ b/.claude/todos/issue-177-worker.md
@@ -1,0 +1,142 @@
+# Issue #177 Worker TODO
+
+## 対象コンポーネント
+Avatar, AvatarGroup, AvatarBadge
+
+## 使用箇所
+
+### ページ
+- `src/pages/profile.tsx` - Avatar (motion wrapped)
+- `src/pages/projects/index.tsx` - Avatar, AvatarGroup
+- `src/pages/projects/[id].tsx` - Avatar, AvatarGroup
+- `src/pages/calendar.tsx` - Avatar
+- `src/pages/team.tsx` - Avatar
+- `src/pages/index.tsx` - Avatar
+- `src/pages/tasks/index.tsx` - Avatar
+
+### コンポーネント
+- `src/components/common/UserAvatar.tsx` - Avatar, AvatarBadge（カスタムラッパー）
+- `src/components/data/MemberCard.tsx` - Avatar
+- `src/components/data/ProjectCard.tsx` - Avatar
+- `src/components/data/TaskCard.tsx` - Avatar
+- `src/components/layout/Header.tsx` - Avatar
+
+## 使用されているprops
+
+### Avatar
+| prop | 型 | 説明 | 使用箇所 |
+|------|-----|------|---------|
+| size | "2xs" \| "xs" \| "sm" \| "md" \| "lg" \| "xl" \| "2xl" | アバターのサイズ | 全般 |
+| name | string | ユーザー名（イニシャル生成・フォールバック用） | 全般 |
+| src | string \| undefined | 画像URL | 全般 |
+
+使用されているsizeの種類:
+- `xs`: index.tsx, ProjectCard.tsx, TaskCard.tsx
+- `sm`: projects/index.tsx, projects/[id].tsx, calendar.tsx, tasks/index.tsx, Header.tsx
+- `md`: projects/[id].tsx
+- `xl`: MemberCard.tsx, team.tsx
+- `2xl`: profile.tsx
+
+### AvatarGroup
+| prop | 型 | 説明 | 使用箇所 |
+|------|-----|------|---------|
+| size | string | 子Avatarのサイズ | projects/index.tsx |
+| max | number | 表示する最大Avatar数（超過分は+Xで表示） | projects/index.tsx |
+
+使用例:
+```tsx
+<AvatarGroup size="sm" max={3}>
+  {members.map((member) => (
+    <Avatar key={member.id} name={member.name} src={member.avatar} />
+  ))}
+</AvatarGroup>
+```
+
+### AvatarBadge
+| prop | 型 | 説明 | 使用箇所 |
+|------|-----|------|---------|
+| boxSize | string | バッジのサイズ（"1em"等） | UserAvatar.tsx |
+| bg | string | 背景色（ステータス表示用） | UserAvatar.tsx |
+| border | string | ボーダー（"2px solid white"等） | UserAvatar.tsx |
+
+使用例:
+```tsx
+<Avatar {...props}>
+  {showStatus && status && (
+    <AvatarBadge
+      boxSize="1em"
+      bg={statusColors[status]}
+      border="2px solid white"
+    />
+  )}
+</Avatar>
+```
+
+## Chakra UI API仕様（参考）
+
+### Avatar
+- `colorScheme`: カラースキーム
+- `size`: サイズ（"2xs" | "xs" | "sm" | "md" | "lg" | "xl" | "2xl" | "full"）、デフォルトは"md"
+- `src`: 画像URL
+- `name`: ユーザー名（イニシャル生成、フォールバック背景色生成に使用）
+- `icon`: カスタムフォールバックアイコン
+- `showBorder`: ボーダー表示
+- `ignoreFallback`: フォールバックロジックを無効化
+- `onError`: 画像読み込みエラー時のコールバック
+- `getInitials`: イニシャル生成のカスタム関数
+- `srcSet`, `loading`, `crossOrigin`, `referrerPolicy`: 画像関連属性
+
+### AvatarGroup
+- `max`: 表示する最大Avatar数
+- `spacing`: Avatar間のスペース（デフォルト: "-0.75rem"）
+- `size`: 子Avatarのサイズ
+- `variant`: バリアント
+
+### AvatarBadge
+- `boxSize`: バッジのサイズ
+- `placement`: 配置位置（デフォルト: "bottom-end"）
+- Boxコンポーネントを継承するためスタイルprops使用可能
+
+## タスク
+1. [pending] src/components/ui/Avatar.tsx を作成
+2. [pending] src/components/ui/Avatar.module.css を作成
+3. [pending] src/components/ui/AvatarGroup.tsx を作成
+4. [pending] src/components/ui/AvatarGroup.module.css を作成
+5. [pending] src/components/ui/AvatarBadge.tsx を作成
+6. [pending] src/components/ui/AvatarBadge.module.css を作成
+7. [pending] src/components/ui/index.ts にexport追加
+8. [pending] src/pages/compare/Avatar.tsx を作成（Chakra版と新版を並べて表示）
+9. [pending] npm run build でエラーがないことを確認
+
+## 実装メモ
+
+### サイズ定義
+Chakra UIのAvatarサイズをピクセル値に変換:
+- `2xs`: 16px
+- `xs`: 24px
+- `sm`: 32px
+- `md`: 48px（デフォルト）
+- `lg`: 64px
+- `xl`: 96px
+- `2xl`: 128px
+
+### イニシャル生成ロジック
+`name` propから最大2文字のイニシャルを生成:
+- "John Doe" → "JD"
+- "山田太郎" → "山田" or "山"（日本語対応検討）
+- "Alice" → "A"
+
+### フォールバック背景色
+`name` propからハッシュ値を生成し、一貫した背景色を割り当てる
+
+### AvatarGroup スタッキング
+- 子Avatarを重ねて表示
+- `max`を超える場合は"+X"ラベルを表示
+- 負のマージンで重なりを表現
+
+### AvatarBadge 配置
+- Avatar内の右下（デフォルト）に絶対配置
+- ステータスインジケーター等に使用
+
+### motion対応
+profile.tsxでは `motion(Avatar)` として使用されているため、コンポーネントがforwardRefで実装されていることを確認

--- a/src/components/ui/Avatar.module.css
+++ b/src/components/ui/Avatar.module.css
@@ -1,0 +1,104 @@
+.avatar {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  border-radius: var(--radius-full);
+  vertical-align: top;
+  font-weight: 500;
+  text-transform: uppercase;
+}
+
+.imageWrapper {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: var(--radius-full);
+  overflow: hidden;
+  z-index: 0;
+}
+
+.size2xs {
+  width: 16px;
+  height: 16px;
+  font-size: 8px;
+}
+
+.sizeXs {
+  width: 24px;
+  height: 24px;
+  font-size: 10px;
+}
+
+.sizeSm {
+  width: 32px;
+  height: 32px;
+  font-size: 12px;
+}
+
+.sizeMd {
+  width: 48px;
+  height: 48px;
+  font-size: 16px;
+}
+
+.sizeLg {
+  width: 64px;
+  height: 64px;
+  font-size: 20px;
+}
+
+.sizeXl {
+  width: 96px;
+  height: 96px;
+  font-size: 28px;
+}
+
+.size2xl {
+  width: 128px;
+  height: 128px;
+  font-size: 36px;
+}
+
+.image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.initials {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  color: var(--color-white);
+  line-height: 1;
+  border-radius: var(--radius-full);
+}
+
+.fallbackIcon {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  background-color: var(--color-gray-400);
+  color: var(--color-white);
+  border-radius: var(--radius-full);
+  overflow: hidden;
+}
+
+.fallbackIcon svg {
+  width: 60%;
+  height: 60%;
+}

--- a/src/components/ui/Avatar.tsx
+++ b/src/components/ui/Avatar.tsx
@@ -1,0 +1,131 @@
+import { forwardRef, HTMLAttributes, ReactNode, useState, createContext, useContext } from 'react';
+import styles from './Avatar.module.css';
+
+export type AvatarSize = '2xs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl';
+
+export interface AvatarProps extends HTMLAttributes<HTMLDivElement> {
+  size?: AvatarSize;
+  name?: string;
+  src?: string;
+  children?: ReactNode;
+}
+
+interface AvatarContextValue {
+  size: AvatarSize;
+}
+
+export const AvatarContext = createContext<AvatarContextValue | null>(null);
+
+export const useAvatarContext = (): AvatarContextValue | null => {
+  return useContext(AvatarContext);
+};
+
+const sizeClassMap: Record<AvatarSize, string> = {
+  '2xs': styles.size2xs,
+  xs: styles.sizeXs,
+  sm: styles.sizeSm,
+  md: styles.sizeMd,
+  lg: styles.sizeLg,
+  xl: styles.sizeXl,
+  '2xl': styles.size2xl,
+};
+
+const backgroundColors = [
+  '#E53E3E',
+  '#DD6B20',
+  '#D69E2E',
+  '#38A169',
+  '#319795',
+  '#3182CE',
+  '#805AD5',
+  '#D53F8C',
+];
+
+const getInitials = (name: string): string => {
+  const parts = name.trim().split(/\s+/);
+  if (parts.length === 1) {
+    return parts[0].charAt(0).toUpperCase();
+  }
+  return (parts[0].charAt(0) + parts[parts.length - 1].charAt(0)).toUpperCase();
+};
+
+const getBackgroundColor = (name: string): string => {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = name.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  const index = Math.abs(hash) % backgroundColors.length;
+  return backgroundColors[index];
+};
+
+const DefaultIcon = () => (
+  <svg viewBox="0 0 128 128" role="img" aria-label="avatar">
+    <g>
+      <path
+        d="M103,102.1388 C93.094,111.92 79.3504,118 64.1638,118 C48.8056,118 34.9294,111.768 25,101.7892 L25,95.2 C25,86.8096 31.981,80 40.6,80 L87.4,80 C96.019,80 103,86.8096 103,95.2 L103,102.1388 Z"
+        fill="currentColor"
+      />
+      <path
+        d="M63.9961647,24 C51.2938136,24 41,34.2938136 41,46.9961647 C41,59.7061864 51.2938136,70 63.9961647,70 C76.6985159,70 87,59.7061864 87,46.9961647 C87,34.2938136 76.6985159,24 63.9961647,24"
+        fill="currentColor"
+      />
+    </g>
+  </svg>
+);
+
+const Avatar = forwardRef<HTMLDivElement, AvatarProps>(
+  ({ size = 'md', name, src, children, className, style, ...props }, ref) => {
+    const [imageError, setImageError] = useState(false);
+
+    const classNames = [styles.avatar, sizeClassMap[size], className]
+      .filter(Boolean)
+      .join(' ');
+
+    const handleImageError = () => {
+      setImageError(true);
+    };
+
+    const showImage = src && !imageError;
+    const showInitials = !showImage && name;
+    const showFallbackIcon = !showImage && !name;
+
+    const backgroundColor = name ? getBackgroundColor(name) : undefined;
+
+    const mergedStyle = {
+      ...style,
+      ...(showInitials ? { backgroundColor } : {}),
+    };
+
+    const contextValue: AvatarContextValue = { size };
+
+    return (
+      <AvatarContext.Provider value={contextValue}>
+        <div ref={ref} className={classNames} style={mergedStyle} {...props}>
+          {showImage && (
+            <div className={styles.imageWrapper}>
+              <img
+                src={src}
+                alt={name || 'avatar'}
+                className={styles.image}
+                onError={handleImageError}
+              />
+            </div>
+          )}
+          {showInitials && (
+            <span className={styles.initials}>{getInitials(name)}</span>
+          )}
+          {showFallbackIcon && (
+            <div className={styles.fallbackIcon}>
+              <DefaultIcon />
+            </div>
+          )}
+          {children}
+        </div>
+      </AvatarContext.Provider>
+    );
+  }
+);
+
+Avatar.displayName = 'Avatar';
+
+export default Avatar;

--- a/src/components/ui/AvatarBadge.module.css
+++ b/src/components/ui/AvatarBadge.module.css
@@ -1,0 +1,12 @@
+.avatarBadge {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  bottom: 0;
+  right: 0;
+  border-radius: 50%;
+  transform: translate(25%, 25%);
+  z-index: 10;
+  box-sizing: border-box;
+}

--- a/src/components/ui/AvatarBadge.tsx
+++ b/src/components/ui/AvatarBadge.tsx
@@ -1,0 +1,48 @@
+import { forwardRef, HTMLAttributes, CSSProperties } from 'react';
+import styles from './AvatarBadge.module.css';
+
+export interface AvatarBadgeProps extends HTMLAttributes<HTMLDivElement> {
+  boxSize?: string;
+  bg?: string;
+  border?: string;
+}
+
+const parseColorValue = (color: string): string => {
+  if (color.includes('.')) {
+    const [colorName, shade] = color.split('.');
+    return `var(--color-${colorName}-${shade})`;
+  }
+  if (color === 'white') return 'var(--color-white)';
+  if (color === 'black') return 'var(--color-black)';
+  return color;
+};
+
+const AvatarBadge = forwardRef<HTMLDivElement, AvatarBadgeProps>(
+  ({ boxSize = '1em', bg, border, className, style, children, ...props }, ref) => {
+    const classNames = [styles.avatarBadge, className].filter(Boolean).join(' ');
+
+    const computedStyle: CSSProperties = {
+      ...style,
+      width: boxSize,
+      height: boxSize,
+    };
+
+    if (bg) {
+      computedStyle.backgroundColor = parseColorValue(bg);
+    }
+
+    if (border) {
+      computedStyle.border = border;
+    }
+
+    return (
+      <div ref={ref} className={classNames} style={computedStyle} {...props}>
+        {children}
+      </div>
+    );
+  }
+);
+
+AvatarBadge.displayName = 'AvatarBadge';
+
+export default AvatarBadge;

--- a/src/components/ui/AvatarGroup.module.css
+++ b/src/components/ui/AvatarGroup.module.css
@@ -1,0 +1,71 @@
+.avatarGroup {
+  display: inline-flex;
+  flex-direction: row-reverse;
+  justify-content: flex-end;
+}
+
+.avatarGroup > * {
+  border: 2px solid var(--color-white);
+}
+
+.avatarGroup > *:not(:last-child) {
+  margin-left: -0.75rem;
+}
+
+.avatarGroupSmall > *:not(:last-child) {
+  margin-left: -0.5rem;
+}
+
+.excessLabel {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  border-radius: var(--radius-full);
+  background-color: var(--color-gray-200);
+  color: var(--color-gray-800);
+  font-weight: 500;
+  border: 2px solid var(--color-white);
+}
+
+.excessSize2xs {
+  width: 16px;
+  height: 16px;
+  font-size: 8px;
+}
+
+.excessSizeXs {
+  width: 24px;
+  height: 24px;
+  font-size: 10px;
+}
+
+.excessSizeSm {
+  width: 32px;
+  height: 32px;
+  font-size: 10px;
+}
+
+.excessSizeMd {
+  width: 48px;
+  height: 48px;
+  font-size: 14px;
+}
+
+.excessSizeLg {
+  width: 64px;
+  height: 64px;
+  font-size: 18px;
+}
+
+.excessSizeXl {
+  width: 96px;
+  height: 96px;
+  font-size: 24px;
+}
+
+.excessSize2xl {
+  width: 128px;
+  height: 128px;
+  font-size: 32px;
+}

--- a/src/components/ui/AvatarGroup.tsx
+++ b/src/components/ui/AvatarGroup.tsx
@@ -1,0 +1,77 @@
+import { forwardRef, HTMLAttributes, ReactNode, Children, cloneElement, isValidElement, Key } from 'react';
+import styles from './AvatarGroup.module.css';
+import { AvatarSize, AvatarProps } from './Avatar';
+
+export interface AvatarGroupProps extends HTMLAttributes<HTMLDivElement> {
+  size?: AvatarSize;
+  max?: number;
+  children?: ReactNode;
+}
+
+const excessSizeClassMap: Record<AvatarSize, string> = {
+  '2xs': styles.excessSize2xs,
+  xs: styles.excessSizeXs,
+  sm: styles.excessSizeSm,
+  md: styles.excessSizeMd,
+  lg: styles.excessSizeLg,
+  xl: styles.excessSizeXl,
+  '2xl': styles.excessSize2xl,
+};
+
+const isAvatarSize = (value: unknown): value is AvatarSize => {
+  return typeof value === 'string' && ['2xs', 'xs', 'sm', 'md', 'lg', 'xl', '2xl'].includes(value);
+};
+
+const isValidKey = (value: unknown): value is Key => {
+  return typeof value === 'string' || typeof value === 'number';
+};
+
+const AvatarGroup = forwardRef<HTMLDivElement, AvatarGroupProps>(
+  ({ size = 'md', max, children, className, ...props }, ref) => {
+    const childArray = Children.toArray(children).filter(isValidElement);
+    const totalCount = childArray.length;
+    const displayCount = max !== undefined && max < totalCount ? max : totalCount;
+    const excessCount = totalCount - displayCount;
+
+    const visibleChildren = childArray.slice(0, displayCount);
+
+    const clonedChildren = visibleChildren.map((child, index) => {
+      if (isValidElement<AvatarProps>(child)) {
+        const childSize = isAvatarSize(child.props.size) ? child.props.size : size;
+        const childKey = isValidKey(child.key) ? child.key : index;
+        return cloneElement(child, {
+          key: childKey,
+          size: childSize,
+        });
+      }
+      return child;
+    });
+
+    const isSmallSize = size === '2xs' || size === 'xs' || size === 'sm';
+
+    const groupClassNames = [
+      styles.avatarGroup,
+      isSmallSize ? styles.avatarGroupSmall : '',
+      className,
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    const excessLabelClassNames = [styles.excessLabel, excessSizeClassMap[size]]
+      .filter(Boolean)
+      .join(' ');
+
+    return (
+      <div ref={ref} className={groupClassNames} {...props}>
+        {excessCount > 0 && (
+          <span className={excessLabelClassNames}>+{excessCount}</span>
+        )}
+        {clonedChildren.reverse()}
+      </div>
+    );
+  }
+);
+
+AvatarGroup.displayName = 'AvatarGroup';
+
+export default AvatarGroup;

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -8,6 +8,10 @@ export { default as StatusBadge } from './StatusBadge';
 export { default as PriorityBadge } from './PriorityBadge';
 export { default as RoleBadge } from './RoleBadge';
 
+export { default as Avatar, AvatarContext, useAvatarContext } from './Avatar';
+export { default as AvatarGroup } from './AvatarGroup';
+export { default as AvatarBadge } from './AvatarBadge';
+
 export { default as Input } from './Input';
 export { default as InputGroup } from './InputGroup';
 export { default as InputLeftElement } from './InputLeftElement';
@@ -72,3 +76,7 @@ export type { FormErrorMessageProps } from './FormErrorMessage';
 export type { FormHelperTextProps } from './FormHelperText';
 
 export type { LayoutProps, ResponsiveValue, SpacingValue, ColorValue, RadiusValue } from './styleUtils';
+
+export type { AvatarSize, AvatarProps } from './Avatar';
+export type { AvatarGroupProps } from './AvatarGroup';
+export type { AvatarBadgeProps } from './AvatarBadge';

--- a/src/pages/compare/Avatar.tsx
+++ b/src/pages/compare/Avatar.tsx
@@ -1,0 +1,298 @@
+import {
+  Box as ChakraBox,
+  Avatar as ChakraAvatar,
+  AvatarGroup as ChakraAvatarGroup,
+  AvatarBadge as ChakraAvatarBadge,
+  SimpleGrid as ChakraSimpleGrid,
+  Text,
+  Heading,
+  HStack as ChakraHStack,
+  VStack as ChakraVStack,
+} from '@chakra-ui/react';
+import {
+  Avatar,
+  AvatarGroup,
+  AvatarBadge,
+  HStack,
+  VStack,
+} from '../../components/ui';
+
+const CompareSection = ({
+  title,
+  chakraVersion,
+  newVersion,
+}: {
+  title: string;
+  chakraVersion: React.ReactNode;
+  newVersion: React.ReactNode;
+}) => (
+  <ChakraBox mb={8}>
+    <Heading size="md" mb={4}>{title}</Heading>
+    <ChakraSimpleGrid columns={2} spacing={4}>
+      <ChakraBox>
+        <Text fontWeight="bold" mb={2} color="blue.600">Chakra UI</Text>
+        <ChakraBox border="1px" borderColor="gray.200" p={4} borderRadius="md">
+          {chakraVersion}
+        </ChakraBox>
+      </ChakraBox>
+      <ChakraBox>
+        <Text fontWeight="bold" mb={2} color="green.600">New (CSS Modules)</Text>
+        <ChakraBox border="1px" borderColor="gray.200" p={4} borderRadius="md">
+          {newVersion}
+        </ChakraBox>
+      </ChakraBox>
+    </ChakraSimpleGrid>
+  </ChakraBox>
+);
+
+const AvatarComparePage = () => {
+  return (
+    <ChakraBox p={8} maxW="1400px" mx="auto">
+      <Heading mb={8}>Avatar Components Comparison</Heading>
+
+      <CompareSection
+        title="Avatar - Basic with Image"
+        chakraVersion={
+          <ChakraHStack spacing={4}>
+            <ChakraAvatar name="John Doe" src="https://i.pravatar.cc/150?u=john" />
+            <ChakraAvatar name="Jane Smith" src="https://i.pravatar.cc/150?u=jane" />
+            <ChakraAvatar name="Bob Wilson" src="https://i.pravatar.cc/150?u=bob" />
+          </ChakraHStack>
+        }
+        newVersion={
+          <HStack spacing={4}>
+            <Avatar name="John Doe" src="https://i.pravatar.cc/150?u=john" />
+            <Avatar name="Jane Smith" src="https://i.pravatar.cc/150?u=jane" />
+            <Avatar name="Bob Wilson" src="https://i.pravatar.cc/150?u=bob" />
+          </HStack>
+        }
+      />
+
+      <CompareSection
+        title="Avatar - Initials Fallback"
+        chakraVersion={
+          <ChakraHStack spacing={4}>
+            <ChakraAvatar name="John Doe" />
+            <ChakraAvatar name="Jane Smith" />
+            <ChakraAvatar name="Alice" />
+            <ChakraAvatar name="Bob Wilson" />
+          </ChakraHStack>
+        }
+        newVersion={
+          <HStack spacing={4}>
+            <Avatar name="John Doe" />
+            <Avatar name="Jane Smith" />
+            <Avatar name="Alice" />
+            <Avatar name="Bob Wilson" />
+          </HStack>
+        }
+      />
+
+      <CompareSection
+        title="Avatar - Default Fallback (No Name)"
+        chakraVersion={
+          <ChakraHStack spacing={4}>
+            <ChakraAvatar />
+            <ChakraAvatar size="lg" />
+            <ChakraAvatar size="xl" />
+          </ChakraHStack>
+        }
+        newVersion={
+          <HStack spacing={4}>
+            <Avatar />
+            <Avatar size="lg" />
+            <Avatar size="xl" />
+          </HStack>
+        }
+      />
+
+      <CompareSection
+        title="Avatar - Sizes"
+        chakraVersion={
+          <ChakraHStack spacing={4} align="center">
+            <ChakraAvatar size="xs" name="XS" />
+            <ChakraAvatar size="sm" name="SM" />
+            <ChakraAvatar size="md" name="MD" />
+            <ChakraAvatar size="lg" name="LG" />
+            <ChakraAvatar size="xl" name="XL" />
+            <ChakraAvatar size="2xl" name="2X" />
+          </ChakraHStack>
+        }
+        newVersion={
+          <HStack spacing={4} align="center">
+            <Avatar size="xs" name="XS" />
+            <Avatar size="sm" name="SM" />
+            <Avatar size="md" name="MD" />
+            <Avatar size="lg" name="LG" />
+            <Avatar size="xl" name="XL" />
+            <Avatar size="2xl" name="2X" />
+          </HStack>
+        }
+      />
+
+      <CompareSection
+        title="AvatarGroup - Basic"
+        chakraVersion={
+          <ChakraAvatarGroup size="md" max={3}>
+            <ChakraAvatar name="John Doe" src="https://i.pravatar.cc/150?u=john" />
+            <ChakraAvatar name="Jane Smith" src="https://i.pravatar.cc/150?u=jane" />
+            <ChakraAvatar name="Bob Wilson" src="https://i.pravatar.cc/150?u=bob" />
+          </ChakraAvatarGroup>
+        }
+        newVersion={
+          <AvatarGroup size="md" max={3}>
+            <Avatar name="John Doe" src="https://i.pravatar.cc/150?u=john" />
+            <Avatar name="Jane Smith" src="https://i.pravatar.cc/150?u=jane" />
+            <Avatar name="Bob Wilson" src="https://i.pravatar.cc/150?u=bob" />
+          </AvatarGroup>
+        }
+      />
+
+      <CompareSection
+        title="AvatarGroup - With Excess"
+        chakraVersion={
+          <ChakraAvatarGroup size="md" max={3}>
+            <ChakraAvatar name="John Doe" src="https://i.pravatar.cc/150?u=john" />
+            <ChakraAvatar name="Jane Smith" src="https://i.pravatar.cc/150?u=jane" />
+            <ChakraAvatar name="Bob Wilson" src="https://i.pravatar.cc/150?u=bob" />
+            <ChakraAvatar name="Alice Brown" src="https://i.pravatar.cc/150?u=alice" />
+            <ChakraAvatar name="Charlie Davis" src="https://i.pravatar.cc/150?u=charlie" />
+          </ChakraAvatarGroup>
+        }
+        newVersion={
+          <AvatarGroup size="md" max={3}>
+            <Avatar name="John Doe" src="https://i.pravatar.cc/150?u=john" />
+            <Avatar name="Jane Smith" src="https://i.pravatar.cc/150?u=jane" />
+            <Avatar name="Bob Wilson" src="https://i.pravatar.cc/150?u=bob" />
+            <Avatar name="Alice Brown" src="https://i.pravatar.cc/150?u=alice" />
+            <Avatar name="Charlie Davis" src="https://i.pravatar.cc/150?u=charlie" />
+          </AvatarGroup>
+        }
+      />
+
+      <CompareSection
+        title="AvatarGroup - Small Size"
+        chakraVersion={
+          <ChakraAvatarGroup size="sm" max={3}>
+            <ChakraAvatar name="John Doe" src="https://i.pravatar.cc/150?u=john" />
+            <ChakraAvatar name="Jane Smith" src="https://i.pravatar.cc/150?u=jane" />
+            <ChakraAvatar name="Bob Wilson" src="https://i.pravatar.cc/150?u=bob" />
+            <ChakraAvatar name="Alice Brown" src="https://i.pravatar.cc/150?u=alice" />
+          </ChakraAvatarGroup>
+        }
+        newVersion={
+          <AvatarGroup size="sm" max={3}>
+            <Avatar name="John Doe" src="https://i.pravatar.cc/150?u=john" />
+            <Avatar name="Jane Smith" src="https://i.pravatar.cc/150?u=jane" />
+            <Avatar name="Bob Wilson" src="https://i.pravatar.cc/150?u=bob" />
+            <Avatar name="Alice Brown" src="https://i.pravatar.cc/150?u=alice" />
+          </AvatarGroup>
+        }
+      />
+
+      <CompareSection
+        title="AvatarBadge - Status Indicator"
+        chakraVersion={
+          <ChakraHStack spacing={4}>
+            <ChakraAvatar name="John Doe" src="https://i.pravatar.cc/150?u=john">
+              <ChakraAvatarBadge boxSize="1em" bg="green.500" border="2px solid white" />
+            </ChakraAvatar>
+            <ChakraAvatar name="Jane Smith" src="https://i.pravatar.cc/150?u=jane">
+              <ChakraAvatarBadge boxSize="1em" bg="red.500" border="2px solid white" />
+            </ChakraAvatar>
+            <ChakraAvatar name="Bob Wilson" src="https://i.pravatar.cc/150?u=bob">
+              <ChakraAvatarBadge boxSize="1em" bg="yellow.500" border="2px solid white" />
+            </ChakraAvatar>
+          </ChakraHStack>
+        }
+        newVersion={
+          <HStack spacing={4}>
+            <Avatar name="John Doe" src="https://i.pravatar.cc/150?u=john">
+              <AvatarBadge boxSize="1em" bg="green.500" border="2px solid white" />
+            </Avatar>
+            <Avatar name="Jane Smith" src="https://i.pravatar.cc/150?u=jane">
+              <AvatarBadge boxSize="1em" bg="red.500" border="2px solid white" />
+            </Avatar>
+            <Avatar name="Bob Wilson" src="https://i.pravatar.cc/150?u=bob">
+              <AvatarBadge boxSize="1em" bg="yellow.500" border="2px solid white" />
+            </Avatar>
+          </HStack>
+        }
+      />
+
+      <CompareSection
+        title="AvatarBadge - Different Sizes"
+        chakraVersion={
+          <ChakraHStack spacing={4} align="center">
+            <ChakraAvatar size="sm" name="Small">
+              <ChakraAvatarBadge boxSize="1em" bg="green.500" border="2px solid white" />
+            </ChakraAvatar>
+            <ChakraAvatar size="md" name="Medium">
+              <ChakraAvatarBadge boxSize="1em" bg="green.500" border="2px solid white" />
+            </ChakraAvatar>
+            <ChakraAvatar size="lg" name="Large">
+              <ChakraAvatarBadge boxSize="1em" bg="green.500" border="2px solid white" />
+            </ChakraAvatar>
+            <ChakraAvatar size="xl" name="XL">
+              <ChakraAvatarBadge boxSize="1em" bg="green.500" border="2px solid white" />
+            </ChakraAvatar>
+          </ChakraHStack>
+        }
+        newVersion={
+          <HStack spacing={4} align="center">
+            <Avatar size="sm" name="Small">
+              <AvatarBadge boxSize="1em" bg="green.500" border="2px solid white" />
+            </Avatar>
+            <Avatar size="md" name="Medium">
+              <AvatarBadge boxSize="1em" bg="green.500" border="2px solid white" />
+            </Avatar>
+            <Avatar size="lg" name="Large">
+              <AvatarBadge boxSize="1em" bg="green.500" border="2px solid white" />
+            </Avatar>
+            <Avatar size="xl" name="XL">
+              <AvatarBadge boxSize="1em" bg="green.500" border="2px solid white" />
+            </Avatar>
+          </HStack>
+        }
+      />
+
+      <CompareSection
+        title="Avatar - Initials with Various Names"
+        chakraVersion={
+          <ChakraVStack spacing={4} align="start">
+            <ChakraHStack spacing={4}>
+              <ChakraAvatar name="John Doe" />
+              <Text>John Doe → JD</Text>
+            </ChakraHStack>
+            <ChakraHStack spacing={4}>
+              <ChakraAvatar name="Alice" />
+              <Text>Alice → A</Text>
+            </ChakraHStack>
+            <ChakraHStack spacing={4}>
+              <ChakraAvatar name="Mary Jane Watson" />
+              <Text>Mary Jane Watson → MW</Text>
+            </ChakraHStack>
+          </ChakraVStack>
+        }
+        newVersion={
+          <VStack spacing={4} align="start">
+            <HStack spacing={4}>
+              <Avatar name="John Doe" />
+              <span>John Doe → JD</span>
+            </HStack>
+            <HStack spacing={4}>
+              <Avatar name="Alice" />
+              <span>Alice → A</span>
+            </HStack>
+            <HStack spacing={4}>
+              <Avatar name="Mary Jane Watson" />
+              <span>Mary Jane Watson → MW</span>
+            </HStack>
+          </VStack>
+        }
+      />
+    </ChakraBox>
+  );
+};
+
+export default AvatarComparePage;


### PR DESCRIPTION
## Summary
- Avatar, AvatarGroup, AvatarBadge コンポーネントをCSS Modulesで実装
- Avatar は画像/イニシャル/デフォルトアイコンのフォールバックをサポート
- AvatarGroup は max prop で表示数制限と "+N" 表示をサポート
- AvatarBadge はステータス表示用バッジ
- 全コンポーネントで forwardRef をサポート

## 追加ファイル
- `src/components/ui/Avatar.tsx` / `Avatar.module.css`
- `src/components/ui/AvatarGroup.tsx` / `AvatarGroup.module.css`
- `src/components/ui/AvatarBadge.tsx` / `AvatarBadge.module.css`
- `src/pages/compare/Avatar.tsx` - 比較ページ

## サポートサイズ
2xs, xs, sm, md, lg, xl, 2xl

## Test plan
- [x] `npm run build` 成功
- [x] `/compare/Avatar` でChakra UI版と新版の見た目が一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)