### PR TITLE
feat: Badgeコンポーネント追加

### DIFF
--- a/.claude/todos/issue-178-reviewer.md
+++ b/.claude/todos/issue-178-reviewer.md
@@ -1,0 +1,35 @@
+# Issue #178 Reviewer TODO
+
+## レビュー観点
+
+### 型定義
+- [ ] BadgeProps が HTMLSpanElement を使用しているか
+- [ ] variant が "solid" | "subtle" | "outline" をサポートしているか
+- [ ] colorScheme が必要なすべての色をサポートしているか
+- [ ] LayoutProps（fontSize, padding など）が継承されているか
+
+### スタイル実装
+- [ ] 7 つの colorScheme × 3 variant = 21 クラスが実装されているか
+- [ ] subtle variant がデフォルトになっているか
+- [ ] フォントサイズがデフォルト、xs, sm に対応しているか
+- [ ] パディングが LayoutProps で制御されているか
+
+### 機能
+- [ ] 子要素（テキスト）が正しく表示されるか
+- [ ] className, style の上書きが可能か
+- [ ] forwardRef が正しく実装されているか
+
+## タスク
+
+1. [pending] コードレビュー（型定義、variant/colorScheme の実装）
+2. [pending] /compare/Badge ページで動作確認
+3. [pending] スクリーンショット取得（Chakra 版と新版を比較）
+4. [pending] 問題があれば修正
+
+## スクリーンショット取得
+
+```bash
+mkdir -p screenshots/issue-178
+agent-browser --cdp 9222 open "http://localhost:3000/compare/Badge"
+agent-browser --cdp 9222 screenshot "/Users/h/lab-chakra-to-css-modules/screenshots/issue-178/compare-badge.png" --full
+```

--- a/.claude/todos/issue-178-worker.md
+++ b/.claude/todos/issue-178-worker.md
@@ -1,0 +1,43 @@
+# Issue #178 Worker TODO
+
+## 調査結果サマリー
+
+Badge コンポーネントは、Chakra UI の Data Display コンポーネントで、ステータスやラベル表示に使用される。プロジェクト内では 19 ファイルで使用されており、主に PriorityBadge, StatusBadge, RoleBadge などのラッパーコンポーネントを通じて活用されている。
+
+### 主要な特性
+- **3 つの variant:** solid, subtle（デフォルト）, outline
+- **複数の colorScheme:** gray, blue, green, orange, red, purple, yellow など
+- **Box 継承:** LayoutProps（fontSize, padding, width など）のサポート
+
+## 使用されている Props
+
+| Prop | 値の例 | 使用箇所 |
+|------|--------|---------|
+| colorScheme | "blue", "green", "gray", "orange", "red", "purple", "yellow" | 全ページで使用 |
+| variant | "subtle"（デフォルト） | index.tsx |
+| fontSize | "xs", "sm" | calendar.tsx, Header.tsx |
+| w | "100%" | calendar.tsx |
+| textAlign | "center" | calendar.tsx |
+| px | 2 | Header.tsx |
+
+## 推奨 colorScheme リスト
+
+| colorScheme | 使用例 |
+|------------|-------|
+| gray | 計画中、デフォルト |
+| blue | 進行中、標準状態 |
+| green | 完了、アクティブ |
+| orange | 保留、警告 |
+| red | 緊急 |
+| purple | オーナー、プレミアム |
+| yellow | 離席中 |
+
+## TODO
+
+1. [pending] src/components/ui/Badge.tsx を作成
+2. [pending] src/components/ui/Badge.module.css を作成
+3. [pending] 7 colorScheme × 3 variant のスタイルクラスを実装
+4. [pending] LayoutProps（fontSize, padding, width など）に対応
+5. [pending] src/components/ui/index.ts に export 追加
+6. [pending] src/pages/compare/Badge.tsx を作成
+7. [pending] npm run build でエラーがないことを確認

--- a/src/components/ui/Badge.module.css
+++ b/src/components/ui/Badge.module.css
@@ -1,0 +1,123 @@
+.badge {
+  display: inline-block;
+  padding: 1px 8px;
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  line-height: 1.5;
+  text-transform: uppercase;
+  border-radius: var(--radius-sm);
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
+.subtleGray {
+  background-color: #EDF2F7;
+  color: #2D3748;
+}
+
+.subtleBlue {
+  background-color: #BEE3F8;
+  color: #2C5282;
+}
+
+.subtleGreen {
+  background-color: #C6F6D5;
+  color: #22543D;
+}
+
+.subtleOrange {
+  background-color: #FEEBC8;
+  color: #7C2D12;
+}
+
+.subtleRed {
+  background-color: #FED7D7;
+  color: #742A2A;
+}
+
+.subtlePurple {
+  background-color: #E9D8FD;
+  color: #6B46C1;
+}
+
+.subtleYellow {
+  background-color: #FEFCBF;
+  color: #744210;
+}
+
+.solidGray {
+  background-color: #718096;
+  color: #FFFFFF;
+}
+
+.solidBlue {
+  background-color: #3182CE;
+  color: #FFFFFF;
+}
+
+.solidGreen {
+  background-color: #38A169;
+  color: #FFFFFF;
+}
+
+.solidOrange {
+  background-color: #DD6B20;
+  color: #FFFFFF;
+}
+
+.solidRed {
+  background-color: #E53E3E;
+  color: #FFFFFF;
+}
+
+.solidPurple {
+  background-color: #805AD5;
+  color: #FFFFFF;
+}
+
+.solidYellow {
+  background-color: #D69E2E;
+  color: #FFFFFF;
+}
+
+.outlineGray {
+  background-color: transparent;
+  color: #718096;
+  box-shadow: inset 0 0 0 1px #718096;
+}
+
+.outlineBlue {
+  background-color: transparent;
+  color: #3182CE;
+  box-shadow: inset 0 0 0 1px #3182CE;
+}
+
+.outlineGreen {
+  background-color: transparent;
+  color: #38A169;
+  box-shadow: inset 0 0 0 1px #38A169;
+}
+
+.outlineOrange {
+  background-color: transparent;
+  color: #DD6B20;
+  box-shadow: inset 0 0 0 1px #DD6B20;
+}
+
+.outlineRed {
+  background-color: transparent;
+  color: #E53E3E;
+  box-shadow: inset 0 0 0 1px #E53E3E;
+}
+
+.outlinePurple {
+  background-color: transparent;
+  color: #805AD5;
+  box-shadow: inset 0 0 0 1px #805AD5;
+}
+
+.outlineYellow {
+  background-color: transparent;
+  color: #D69E2E;
+  box-shadow: inset 0 0 0 1px #D69E2E;
+}

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -1,0 +1,79 @@
+import { forwardRef, HTMLAttributes, ReactNode } from 'react';
+import styles from './Badge.module.css';
+import { buildStyles, LayoutProps, extractLayoutProps, mergeStyles } from './styleUtils';
+
+export type BadgeVariant = 'solid' | 'subtle' | 'outline';
+export type BadgeColorScheme = 'gray' | 'blue' | 'green' | 'orange' | 'red' | 'purple' | 'yellow';
+
+export interface BadgeProps extends Omit<HTMLAttributes<HTMLSpanElement>, 'color'>, LayoutProps {
+  variant?: BadgeVariant;
+  colorScheme?: BadgeColorScheme;
+  children?: ReactNode;
+}
+
+const variantColorClassMap: Record<BadgeVariant, Record<BadgeColorScheme, string>> = {
+  solid: {
+    gray: styles.solidGray,
+    blue: styles.solidBlue,
+    green: styles.solidGreen,
+    orange: styles.solidOrange,
+    red: styles.solidRed,
+    purple: styles.solidPurple,
+    yellow: styles.solidYellow,
+  },
+  subtle: {
+    gray: styles.subtleGray,
+    blue: styles.subtleBlue,
+    green: styles.subtleGreen,
+    orange: styles.subtleOrange,
+    red: styles.subtleRed,
+    purple: styles.subtlePurple,
+    yellow: styles.subtleYellow,
+  },
+  outline: {
+    gray: styles.outlineGray,
+    blue: styles.outlineBlue,
+    green: styles.outlineGreen,
+    orange: styles.outlineOrange,
+    red: styles.outlineRed,
+    purple: styles.outlinePurple,
+    yellow: styles.outlineYellow,
+  },
+};
+
+const Badge = forwardRef<HTMLSpanElement, BadgeProps>(
+  (
+    {
+      variant = 'subtle',
+      colorScheme = 'gray',
+      children,
+      className,
+      style,
+      ...props
+    },
+    ref
+  ) => {
+    const { layoutProps, rest } = extractLayoutProps(props);
+    const { style: layoutStyle } = buildStyles(layoutProps);
+
+    const classNames = [
+      styles.badge,
+      variantColorClassMap[variant][colorScheme],
+      className,
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    const mergedStyle = mergeStyles(layoutStyle, style);
+
+    return (
+      <span ref={ref} className={classNames} style={mergedStyle} {...rest}>
+        {children}
+      </span>
+    );
+  }
+);
+
+Badge.displayName = 'Badge';
+
+export default Badge;

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -11,6 +11,7 @@ export { default as RoleBadge } from './RoleBadge';
 export { default as Avatar, AvatarContext, useAvatarContext } from './Avatar';
 export { default as AvatarGroup } from './AvatarGroup';
 export { default as AvatarBadge } from './AvatarBadge';
+export { default as Badge } from './Badge';
 
 export { default as Input } from './Input';
 export { default as InputGroup } from './InputGroup';
@@ -80,3 +81,5 @@ export type { LayoutProps, ResponsiveValue, SpacingValue, ColorValue, RadiusValu
 export type { AvatarSize, AvatarProps } from './Avatar';
 export type { AvatarGroupProps } from './AvatarGroup';
 export type { AvatarBadgeProps } from './AvatarBadge';
+
+export type { BadgeVariant, BadgeColorScheme, BadgeProps } from './Badge';

--- a/src/pages/compare/Badge.tsx
+++ b/src/pages/compare/Badge.tsx
@@ -1,0 +1,252 @@
+import {
+  Box as ChakraBox,
+  Badge as ChakraBadge,
+  SimpleGrid as ChakraSimpleGrid,
+  Text,
+  Heading,
+  HStack as ChakraHStack,
+  VStack as ChakraVStack,
+} from '@chakra-ui/react';
+import {
+  Badge,
+  HStack,
+  VStack,
+} from '../../components/ui';
+
+const CompareSection = ({
+  title,
+  chakraVersion,
+  newVersion,
+}: {
+  title: string;
+  chakraVersion: React.ReactNode;
+  newVersion: React.ReactNode;
+}) => (
+  <ChakraBox mb={8}>
+    <Heading size="md" mb={4}>{title}</Heading>
+    <ChakraSimpleGrid columns={2} spacing={4}>
+      <ChakraBox>
+        <Text fontWeight="bold" mb={2} color="blue.600">Chakra UI</Text>
+        <ChakraBox border="1px" borderColor="gray.200" p={4} borderRadius="md">
+          {chakraVersion}
+        </ChakraBox>
+      </ChakraBox>
+      <ChakraBox>
+        <Text fontWeight="bold" mb={2} color="green.600">New (CSS Modules)</Text>
+        <ChakraBox border="1px" borderColor="gray.200" p={4} borderRadius="md">
+          {newVersion}
+        </ChakraBox>
+      </ChakraBox>
+    </ChakraSimpleGrid>
+  </ChakraBox>
+);
+
+const colorSchemes = ['gray', 'blue', 'green', 'orange', 'red', 'purple', 'yellow'] as const;
+
+const BadgeComparePage = () => {
+  return (
+    <ChakraBox p={8} maxW="1400px" mx="auto">
+      <Heading mb={8}>Badge Components Comparison</Heading>
+
+      <CompareSection
+        title="Badge - Subtle Variant (Default)"
+        chakraVersion={
+          <ChakraHStack spacing={2} wrap="wrap">
+            {colorSchemes.map((color) => (
+              <ChakraBadge key={color} colorScheme={color}>
+                {color}
+              </ChakraBadge>
+            ))}
+          </ChakraHStack>
+        }
+        newVersion={
+          <HStack spacing={2} flexWrap="wrap">
+            {colorSchemes.map((color) => (
+              <Badge key={color} colorScheme={color}>
+                {color}
+              </Badge>
+            ))}
+          </HStack>
+        }
+      />
+
+      <CompareSection
+        title="Badge - Solid Variant"
+        chakraVersion={
+          <ChakraHStack spacing={2} wrap="wrap">
+            {colorSchemes.map((color) => (
+              <ChakraBadge key={color} colorScheme={color} variant="solid">
+                {color}
+              </ChakraBadge>
+            ))}
+          </ChakraHStack>
+        }
+        newVersion={
+          <HStack spacing={2} flexWrap="wrap">
+            {colorSchemes.map((color) => (
+              <Badge key={color} colorScheme={color} variant="solid">
+                {color}
+              </Badge>
+            ))}
+          </HStack>
+        }
+      />
+
+      <CompareSection
+        title="Badge - Outline Variant"
+        chakraVersion={
+          <ChakraHStack spacing={2} wrap="wrap">
+            {colorSchemes.map((color) => (
+              <ChakraBadge key={color} colorScheme={color} variant="outline">
+                {color}
+              </ChakraBadge>
+            ))}
+          </ChakraHStack>
+        }
+        newVersion={
+          <HStack spacing={2} flexWrap="wrap">
+            {colorSchemes.map((color) => (
+              <Badge key={color} colorScheme={color} variant="outline">
+                {color}
+              </Badge>
+            ))}
+          </HStack>
+        }
+      />
+
+      <CompareSection
+        title="Badge - All Variants for Blue"
+        chakraVersion={
+          <ChakraHStack spacing={4}>
+            <ChakraVStack align="start">
+              <Text fontSize="sm">subtle:</Text>
+              <ChakraBadge colorScheme="blue" variant="subtle">Badge</ChakraBadge>
+            </ChakraVStack>
+            <ChakraVStack align="start">
+              <Text fontSize="sm">solid:</Text>
+              <ChakraBadge colorScheme="blue" variant="solid">Badge</ChakraBadge>
+            </ChakraVStack>
+            <ChakraVStack align="start">
+              <Text fontSize="sm">outline:</Text>
+              <ChakraBadge colorScheme="blue" variant="outline">Badge</ChakraBadge>
+            </ChakraVStack>
+          </ChakraHStack>
+        }
+        newVersion={
+          <HStack spacing={4}>
+            <VStack align="start">
+              <span style={{ fontSize: '0.875rem' }}>subtle:</span>
+              <Badge colorScheme="blue" variant="subtle">Badge</Badge>
+            </VStack>
+            <VStack align="start">
+              <span style={{ fontSize: '0.875rem' }}>solid:</span>
+              <Badge colorScheme="blue" variant="solid">Badge</Badge>
+            </VStack>
+            <VStack align="start">
+              <span style={{ fontSize: '0.875rem' }}>outline:</span>
+              <Badge colorScheme="blue" variant="outline">Badge</Badge>
+            </VStack>
+          </HStack>
+        }
+      />
+
+      <CompareSection
+        title="Badge - fontSize (xs, sm)"
+        chakraVersion={
+          <ChakraHStack spacing={4} align="center">
+            <ChakraBadge colorScheme="blue" fontSize="xs">fontSize xs</ChakraBadge>
+            <ChakraBadge colorScheme="blue" fontSize="sm">fontSize sm</ChakraBadge>
+          </ChakraHStack>
+        }
+        newVersion={
+          <HStack spacing={4} align="center">
+            <Badge colorScheme="blue" fontSize="xs">fontSize xs</Badge>
+            <Badge colorScheme="blue" fontSize="sm">fontSize sm</Badge>
+          </HStack>
+        }
+      />
+
+      <CompareSection
+        title="Badge - width (w='100%')"
+        chakraVersion={
+          <ChakraVStack spacing={2} align="stretch">
+            <ChakraBadge colorScheme="green" textAlign="center" w="100%">Full Width</ChakraBadge>
+            <ChakraBadge colorScheme="blue" textAlign="center">Normal</ChakraBadge>
+          </ChakraVStack>
+        }
+        newVersion={
+          <VStack spacing={2} align="stretch">
+            <Badge colorScheme="green" textAlign="center" w="100%">Full Width</Badge>
+            <Badge colorScheme="blue" textAlign="center">Normal</Badge>
+          </VStack>
+        }
+      />
+
+      <CompareSection
+        title="Badge - padding (px)"
+        chakraVersion={
+          <ChakraHStack spacing={4}>
+            <ChakraBadge colorScheme="purple">Default</ChakraBadge>
+            <ChakraBadge colorScheme="purple" px={4}>px=4</ChakraBadge>
+            <ChakraBadge colorScheme="purple" px={6}>px=6</ChakraBadge>
+          </ChakraHStack>
+        }
+        newVersion={
+          <HStack spacing={4}>
+            <Badge colorScheme="purple">Default</Badge>
+            <Badge colorScheme="purple" px={4}>px=4</Badge>
+            <Badge colorScheme="purple" px={6}>px=6</Badge>
+          </HStack>
+        }
+      />
+
+      <CompareSection
+        title="Badge - Use Cases"
+        chakraVersion={
+          <ChakraVStack spacing={3} align="start">
+            <ChakraHStack>
+              <Text>Status:</Text>
+              <ChakraBadge colorScheme="green">Active</ChakraBadge>
+              <ChakraBadge colorScheme="red">Inactive</ChakraBadge>
+              <ChakraBadge colorScheme="yellow">Pending</ChakraBadge>
+            </ChakraHStack>
+            <ChakraHStack>
+              <Text>Priority:</Text>
+              <ChakraBadge colorScheme="red" variant="solid">High</ChakraBadge>
+              <ChakraBadge colorScheme="orange" variant="solid">Medium</ChakraBadge>
+              <ChakraBadge colorScheme="gray" variant="solid">Low</ChakraBadge>
+            </ChakraHStack>
+            <ChakraHStack>
+              <Text>Role:</Text>
+              <ChakraBadge colorScheme="purple" variant="outline">Owner</ChakraBadge>
+              <ChakraBadge colorScheme="blue" variant="outline">Member</ChakraBadge>
+            </ChakraHStack>
+          </ChakraVStack>
+        }
+        newVersion={
+          <VStack spacing={3} align="start">
+            <HStack>
+              <span>Status:</span>
+              <Badge colorScheme="green">Active</Badge>
+              <Badge colorScheme="red">Inactive</Badge>
+              <Badge colorScheme="yellow">Pending</Badge>
+            </HStack>
+            <HStack>
+              <span>Priority:</span>
+              <Badge colorScheme="red" variant="solid">High</Badge>
+              <Badge colorScheme="orange" variant="solid">Medium</Badge>
+              <Badge colorScheme="gray" variant="solid">Low</Badge>
+            </HStack>
+            <HStack>
+              <span>Role:</span>
+              <Badge colorScheme="purple" variant="outline">Owner</Badge>
+              <Badge colorScheme="blue" variant="outline">Member</Badge>
+            </HStack>
+          </VStack>
+        }
+      />
+    </ChakraBox>
+  );
+};
+
+export default BadgeComparePage;


### PR DESCRIPTION
## Summary
- Badge コンポーネントを CSS Modules で新規作成
- 3 つの variant (solid, subtle, outline) と 7 つの colorScheme をサポート
- LayoutProps (fontSize, padding, width など) に対応

## Closes
#178

## Test plan
- [x] `npm run build` が成功することを確認
- [x] `/compare/Badge` で Chakra 版と CSS Modules 版を比較確認
- [x] スクリーンショット取得済み (`screenshots/issue-178/compare-badge.png`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)