### PR TITLE
feat: Cardコンポーネント追加 (Card, CardHeader, CardBody)

### DIFF
--- a/.claude/todos/issue-179-reviewer.md
+++ b/.claude/todos/issue-179-reviewer.md
@@ -1,0 +1,15 @@
+# issue-179 Reviewer TODO
+
+## TODO
+
+1. [pending] コードレビュー（型定義、props、スタイル）
+   - Card, CardHeader, CardBody の型定義が適切か
+   - Chakra UIのCardと同等のpropsがサポートされているか
+   - CSSスタイルがChakra UIと一致しているか
+2. [pending] /compare/Card ページで動作確認
+   - Chakra UI版と新版の表示が一致しているか
+   - bgプロパティが正しく動作するか
+   - CardBodyのp=0が正しく動作するか
+   - styleプロパティ（グラデーション背景）が正しく動作するか
+3. [pending] スクリーンショット取得・比較
+4. [pending] 問題があれば修正

--- a/.claude/todos/issue-179-worker.md
+++ b/.claude/todos/issue-179-worker.md
@@ -1,0 +1,60 @@
+# issue-179 Worker TODO
+
+対象コンポーネント: Card, CardHeader, CardBody
+
+## 使用されているprops
+
+### Card
+| prop | 使用箇所 | 値 |
+|------|---------|-----|
+| (デフォルト) | src/pages/index.tsx, src/pages/projects/[id].tsx, src/pages/tasks/new.tsx, src/pages/tasks/[id]/edit.tsx, src/components/data/StatCard.tsx | - |
+| bg | src/pages/tasks/[id]/edit.tsx | "gray.50" |
+| style | src/pages/index.tsx | { background: 'linear-gradient(...)' } |
+
+### CardHeader
+| prop | 使用箇所 | 値 |
+|------|---------|-----|
+| (デフォルト) | src/pages/index.tsx, src/pages/projects/[id].tsx | - |
+
+### CardBody
+| prop | 使用箇所 | 値 |
+|------|---------|-----|
+| (デフォルト) | src/pages/index.tsx, src/pages/projects/[id].tsx, src/pages/tasks/new.tsx, src/pages/tasks/[id]/edit.tsx, src/components/data/StatCard.tsx | - |
+| p | src/pages/projects/[id].tsx | 0 |
+
+## 注意事項
+
+- 既存の `src/components/ui/Card.tsx` は独自実装（BoxベースでisHoverable propを持つ）
+- Chakra UIのCard, CardHeader, CardBodyは別途 `@chakra-ui/react` からimportされている
+- 新しいCard.tsxは、Chakra UIのCard, CardHeader, CardBodyを置き換える必要がある
+- 既存のCard.tsxの機能（isHoverable）も統合するか検討が必要
+
+## Chakra UI Cardのデフォルトスタイル（theme/index.ts）
+
+```typescript
+Card: {
+  baseStyle: {
+    container: {
+      bg: 'white',
+      borderRadius: 'lg',
+      boxShadow: 'sm',
+      _hover: {
+        boxShadow: 'md',
+      },
+      transition: 'box-shadow 0.2s',
+    },
+  },
+},
+```
+
+## TODO
+
+1. [pending] src/components/ui/Card.tsx を書き換え（Card, CardHeader, CardBody を実装）
+2. [pending] src/components/ui/Card.module.css を作成
+3. [pending] 必要なpropsを実装
+   - Card: bg, style, children
+   - CardHeader: children
+   - CardBody: p, children
+4. [pending] src/components/ui/index.ts にexport追加（CardHeader, CardBody）
+5. [pending] src/pages/compare/Card.tsx を作成（Chakra版と新版を並べて表示）
+6. [pending] npm run build でエラーがないことを確認

--- a/src/components/ui/Card.module.css
+++ b/src/components/ui/Card.module.css
@@ -1,0 +1,26 @@
+.card {
+  background: var(--color-white);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+}
+
+.hoverable {
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.hoverable:hover {
+  border-color: var(--color-primary-300);
+  background: var(--color-gray-50);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
+}
+
+.cardHeader {
+  padding: calc(var(--spacing) * 5);
+  padding-bottom: 0;
+}
+
+.cardBody {
+  padding: calc(var(--spacing) * 5);
+}

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,48 +1,73 @@
-import {
-  Box,
-  BoxProps,
-  useColorModeValue,
-} from '@chakra-ui/react';
-import { ReactNode } from 'react';
+import { forwardRef, HTMLAttributes, ReactNode, CSSProperties } from 'react';
+import styles from './Card.module.css';
+import { buildStyles, LayoutProps, extractLayoutProps, mergeStyles } from './styleUtils';
 
-interface CardProps extends BoxProps {
-  children: ReactNode;
+export interface CardProps extends Omit<HTMLAttributes<HTMLDivElement>, 'color'>, LayoutProps {
+  children?: ReactNode;
   isHoverable?: boolean;
 }
 
-export default function Card({
-  children,
-  isHoverable = false,
-  ...props
-}: CardProps) {
-  const bgColor = useColorModeValue('white', 'gray.800');
-  const borderColor = useColorModeValue('gray.200', 'gray.700');
-
-  const hoverStyles = isHoverable
-    ? {
-        _hover: {
-          borderColor: 'primary.300',
-          bg: 'gray.50',
-          transform: 'translateY(-2px)',
-          boxShadow: 'md',
-        },
-        transition: 'all 0.2s',
-        cursor: 'pointer',
-      }
-    : {};
-
-  return (
-    <Box
-      p={4}
-      borderRadius="lg"
-      border="1px"
-      borderColor={borderColor}
-      bg={bgColor}
-      boxShadow="sm"
-      {...hoverStyles}
-      {...props}
-    >
-      {children}
-    </Box>
-  );
+export interface CardHeaderProps extends HTMLAttributes<HTMLDivElement> {
+  children?: ReactNode;
 }
+
+export interface CardBodyProps extends Omit<HTMLAttributes<HTMLDivElement>, 'color'>, LayoutProps {
+  children?: ReactNode;
+}
+
+const Card = forwardRef<HTMLDivElement, CardProps>(
+  ({ children, className, style, isHoverable = false, ...props }, ref) => {
+    const { layoutProps, rest } = extractLayoutProps(props);
+    const { style: layoutStyle } = buildStyles(layoutProps);
+
+    const classNames = [styles.card, isHoverable && styles.hoverable, className]
+      .filter(Boolean)
+      .join(' ');
+
+    const mergedStyle = mergeStyles(layoutStyle, style);
+
+    return (
+      <div ref={ref} className={classNames} style={mergedStyle} {...rest}>
+        {children}
+      </div>
+    );
+  }
+);
+
+Card.displayName = 'Card';
+
+const CardHeader = forwardRef<HTMLDivElement, CardHeaderProps>(
+  ({ children, className, style, ...props }, ref) => {
+    const classNames = [styles.cardHeader, className].filter(Boolean).join(' ');
+
+    return (
+      <div ref={ref} className={classNames} style={style} {...props}>
+        {children}
+      </div>
+    );
+  }
+);
+
+CardHeader.displayName = 'CardHeader';
+
+const CardBody = forwardRef<HTMLDivElement, CardBodyProps>(
+  ({ children, className, style, ...props }, ref) => {
+    const { layoutProps, rest } = extractLayoutProps(props);
+    const { style: layoutStyle } = buildStyles(layoutProps);
+
+    const classNames = [styles.cardBody, className].filter(Boolean).join(' ');
+
+    const mergedStyle = mergeStyles(layoutStyle, style);
+
+    return (
+      <div ref={ref} className={classNames} style={mergedStyle} {...rest}>
+        {children}
+      </div>
+    );
+  }
+);
+
+CardBody.displayName = 'CardBody';
+
+export default Card;
+export { CardHeader, CardBody };

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,7 +1,7 @@
 export { default as Button } from './Button';
 export { default as IconButton } from './IconButton';
 export { default as CloseButton } from './CloseButton';
-export { default as Card } from './Card';
+export { default as Card, CardHeader, CardBody } from './Card';
 export { default as ProgressBar } from './ProgressBar';
 export { default as EmptyState } from './EmptyState';
 export { default as StatusBadge } from './StatusBadge';
@@ -44,6 +44,7 @@ export { default as Heading } from './Heading';
 export type { ButtonVariant, ButtonSize, ButtonColorScheme, ButtonProps } from './Button';
 export type { IconButtonVariant, IconButtonSize, IconButtonColorScheme, IconButtonProps } from './IconButton';
 export type { CloseButtonSize, CloseButtonProps } from './CloseButton';
+export type { CardProps, CardHeaderProps, CardBodyProps } from './Card';
 export type { TaskStatus, ProjectStatus, UserStatus } from './StatusBadge';
 export type { Priority } from './PriorityBadge';
 export type { Role } from './RoleBadge';

--- a/src/pages/compare/Card.tsx
+++ b/src/pages/compare/Card.tsx
@@ -1,0 +1,279 @@
+import {
+  Box as ChakraBox,
+  Card as ChakraCard,
+  CardHeader as ChakraCardHeader,
+  CardBody as ChakraCardBody,
+  SimpleGrid as ChakraSimpleGrid,
+  Text,
+  Heading,
+  VStack as ChakraVStack,
+  HStack as ChakraHStack,
+  Stat,
+  StatLabel,
+  StatNumber,
+} from '@chakra-ui/react';
+import {
+  Card,
+  CardHeader,
+  CardBody,
+  HStack,
+  VStack,
+} from '../../components/ui';
+
+const CompareSection = ({
+  title,
+  chakraVersion,
+  newVersion,
+}: {
+  title: string;
+  chakraVersion: React.ReactNode;
+  newVersion: React.ReactNode;
+}) => (
+  <ChakraBox mb={8}>
+    <Heading size="md" mb={4}>{title}</Heading>
+    <ChakraSimpleGrid columns={2} spacing={4}>
+      <ChakraBox>
+        <Text fontWeight="bold" mb={2} color="blue.600">Chakra UI</Text>
+        <ChakraBox border="1px" borderColor="gray.200" p={4} borderRadius="md">
+          {chakraVersion}
+        </ChakraBox>
+      </ChakraBox>
+      <ChakraBox>
+        <Text fontWeight="bold" mb={2} color="green.600">New (CSS Modules)</Text>
+        <ChakraBox border="1px" borderColor="gray.200" p={4} borderRadius="md">
+          {newVersion}
+        </ChakraBox>
+      </ChakraBox>
+    </ChakraSimpleGrid>
+  </ChakraBox>
+);
+
+const CardComparePage = () => {
+  return (
+    <ChakraBox p={8} maxW="1400px" mx="auto">
+      <Heading mb={8}>Card Components Comparison</Heading>
+
+      <CompareSection
+        title="Card - Default"
+        chakraVersion={
+          <ChakraCard>
+            <ChakraCardBody>
+              <Text>This is a default card.</Text>
+            </ChakraCardBody>
+          </ChakraCard>
+        }
+        newVersion={
+          <Card>
+            <CardBody>
+              <span>This is a default card.</span>
+            </CardBody>
+          </Card>
+        }
+      />
+
+      <CompareSection
+        title="Card with Header and Body"
+        chakraVersion={
+          <ChakraCard>
+            <ChakraCardHeader>
+              <Heading size="md">Card Title</Heading>
+            </ChakraCardHeader>
+            <ChakraCardBody>
+              <Text>Card body content goes here.</Text>
+            </ChakraCardBody>
+          </ChakraCard>
+        }
+        newVersion={
+          <Card>
+            <CardHeader>
+              <span style={{ fontSize: '1.25rem', fontWeight: 600 }}>Card Title</span>
+            </CardHeader>
+            <CardBody>
+              <span>Card body content goes here.</span>
+            </CardBody>
+          </Card>
+        }
+      />
+
+      <CompareSection
+        title="Card with bg prop (gray.50)"
+        chakraVersion={
+          <ChakraCard bg="gray.50">
+            <ChakraCardBody>
+              <Text>Card with gray.50 background.</Text>
+            </ChakraCardBody>
+          </ChakraCard>
+        }
+        newVersion={
+          <Card bg="gray.50">
+            <CardBody>
+              <span>Card with gray.50 background.</span>
+            </CardBody>
+          </Card>
+        }
+      />
+
+      <CompareSection
+        title="Card with style prop (gradient)"
+        chakraVersion={
+          <ChakraCard style={{ background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)', color: 'white' }}>
+            <ChakraCardBody>
+              <Text>Card with gradient background.</Text>
+            </ChakraCardBody>
+          </ChakraCard>
+        }
+        newVersion={
+          <Card style={{ background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)', color: 'white' }}>
+            <CardBody>
+              <span>Card with gradient background.</span>
+            </CardBody>
+          </Card>
+        }
+      />
+
+      <CompareSection
+        title="CardBody with p={0}"
+        chakraVersion={
+          <ChakraCard>
+            <ChakraCardHeader>
+              <Heading size="md">Header</Heading>
+            </ChakraCardHeader>
+            <ChakraCardBody p={0}>
+              <ChakraBox bg="gray.100" p={4}>
+                <Text>Body with p=0 (no padding)</Text>
+              </ChakraBox>
+            </ChakraCardBody>
+          </ChakraCard>
+        }
+        newVersion={
+          <Card>
+            <CardHeader>
+              <span style={{ fontSize: '1.25rem', fontWeight: 600 }}>Header</span>
+            </CardHeader>
+            <CardBody p={0}>
+              <div style={{ background: 'var(--color-gray-100)', padding: 'calc(var(--spacing) * 4)' }}>
+                <span>Body with p=0 (no padding)</span>
+              </div>
+            </CardBody>
+          </Card>
+        }
+      />
+
+      <CompareSection
+        title="Card - isHoverable (existing feature)"
+        chakraVersion={
+          <ChakraVStack spacing={4}>
+            <Text fontSize="sm" color="gray.600">Chakra UI Card does not have isHoverable prop by default</Text>
+            <ChakraCard _hover={{ boxShadow: 'md', transform: 'translateY(-2px)' }} transition="all 0.2s" cursor="pointer">
+              <ChakraCardBody>
+                <Text>Hover over this card</Text>
+              </ChakraCardBody>
+            </ChakraCard>
+          </ChakraVStack>
+        }
+        newVersion={
+          <VStack spacing={4}>
+            <span style={{ fontSize: '0.875rem', color: 'var(--color-gray-600)' }}>New Card supports isHoverable prop</span>
+            <Card isHoverable>
+              <CardBody>
+                <span>Hover over this card</span>
+              </CardBody>
+            </Card>
+          </VStack>
+        }
+      />
+
+      <CompareSection
+        title="Multiple Cards Layout"
+        chakraVersion={
+          <ChakraSimpleGrid columns={2} spacing={4}>
+            <ChakraCard>
+              <ChakraCardBody>
+                <Stat>
+                  <StatLabel>Total Users</StatLabel>
+                  <StatNumber>1,234</StatNumber>
+                </Stat>
+              </ChakraCardBody>
+            </ChakraCard>
+            <ChakraCard>
+              <ChakraCardBody>
+                <Stat>
+                  <StatLabel>Active Sessions</StatLabel>
+                  <StatNumber>567</StatNumber>
+                </Stat>
+              </ChakraCardBody>
+            </ChakraCard>
+          </ChakraSimpleGrid>
+        }
+        newVersion={
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 'calc(var(--spacing) * 4)' }}>
+            <Card>
+              <CardBody>
+                <VStack align="start" spacing={1}>
+                  <span style={{ fontSize: '0.875rem', color: 'var(--color-gray-600)' }}>Total Users</span>
+                  <span style={{ fontSize: '1.5rem', fontWeight: 600 }}>1,234</span>
+                </VStack>
+              </CardBody>
+            </Card>
+            <Card>
+              <CardBody>
+                <VStack align="start" spacing={1}>
+                  <span style={{ fontSize: '0.875rem', color: 'var(--color-gray-600)' }}>Active Sessions</span>
+                  <span style={{ fontSize: '1.5rem', fontWeight: 600 }}>567</span>
+                </VStack>
+              </CardBody>
+            </Card>
+          </div>
+        }
+      />
+
+      <CompareSection
+        title="Card with Full Content"
+        chakraVersion={
+          <ChakraCard>
+            <ChakraCardHeader>
+              <ChakraHStack justify="space-between">
+                <Heading size="md">Project Status</Heading>
+                <Text color="blue.500" fontSize="sm">View All</Text>
+              </ChakraHStack>
+            </ChakraCardHeader>
+            <ChakraCardBody>
+              <ChakraVStack align="stretch" spacing={3}>
+                <ChakraHStack justify="space-between">
+                  <Text>Task Completion</Text>
+                  <Text fontWeight="bold">75%</Text>
+                </ChakraHStack>
+                <ChakraBox h="8px" bg="gray.200" borderRadius="full">
+                  <ChakraBox h="full" w="75%" bg="blue.500" borderRadius="full" />
+                </ChakraBox>
+              </ChakraVStack>
+            </ChakraCardBody>
+          </ChakraCard>
+        }
+        newVersion={
+          <Card>
+            <CardHeader>
+              <HStack justifyContent="space-between">
+                <span style={{ fontSize: '1.25rem', fontWeight: 600 }}>Project Status</span>
+                <span style={{ color: 'var(--color-blue-500)', fontSize: '0.875rem' }}>View All</span>
+              </HStack>
+            </CardHeader>
+            <CardBody>
+              <VStack align="stretch" spacing={3}>
+                <HStack justifyContent="space-between">
+                  <span>Task Completion</span>
+                  <span style={{ fontWeight: 600 }}>75%</span>
+                </HStack>
+                <div style={{ height: '8px', background: 'var(--color-gray-200)', borderRadius: '9999px' }}>
+                  <div style={{ height: '100%', width: '75%', background: 'var(--color-blue-500)', borderRadius: '9999px' }} />
+                </div>
+              </VStack>
+            </CardBody>
+          </Card>
+        }
+      />
+    </ChakraBox>
+  );
+};
+
+export default CardComparePage;


### PR DESCRIPTION
## Summary

- Card, CardHeader, CardBody コンポーネントを CSS Modules で実装
- Chakra UI の Card と同等のスタイル・機能を提供
- isHoverable prop（既存機能）を維持

## 実装したコンポーネント

| コンポーネント | props |
|-------------|-------|
| Card | children, bg, style, isHoverable |
| CardHeader | children |
| CardBody | children, p |

## ファイル構成

- `src/components/ui/Card.tsx` - Card, CardHeader, CardBody コンポーネント
- `src/components/ui/Card.module.css` - スタイル定義
- `src/pages/compare/Card.tsx` - 比較ページ

## 比較スクリーンショット

![compare-card](screenshots/issue-179/compare-card-fixed.png)

## Test plan

- [x] npm run build でエラーがないことを確認
- [x] /compare/Card ページで Chakra UI 版と CSS Modules 版の表示が一致することを確認
- [x] スクリーンショットを取得

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)