### PR TITLE
feat: Modalコンポーネント追加

### DIFF
--- a/src/components/ui/Modal.module.css
+++ b/src/components/ui/Modal.module.css
@@ -1,0 +1,140 @@
+.modalRoot {
+  position: fixed;
+  inset: 0;
+  z-index: 1400;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  overflow: auto;
+}
+
+.overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.48);
+  z-index: 1400;
+}
+
+.content {
+  position: relative;
+  z-index: 1401;
+  background: var(--color-white);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+  margin: 3.75rem auto;
+  max-height: calc(100% - 7.5rem);
+  display: flex;
+  flex-direction: column;
+}
+
+.centered {
+  margin-top: auto;
+  margin-bottom: auto;
+}
+
+.sizeXs {
+  width: 100%;
+  max-width: 20rem;
+}
+
+.sizeSm {
+  width: 100%;
+  max-width: 24rem;
+}
+
+.sizeMd {
+  width: 100%;
+  max-width: 28rem;
+}
+
+.sizeLg {
+  width: 100%;
+  max-width: 32rem;
+}
+
+.sizeXl {
+  width: 100%;
+  max-width: 36rem;
+}
+
+.size2xl {
+  width: 100%;
+  max-width: 42rem;
+}
+
+.size3xl {
+  width: 100%;
+  max-width: 48rem;
+}
+
+.size4xl {
+  width: 100%;
+  max-width: 56rem;
+}
+
+.size5xl {
+  width: 100%;
+  max-width: 64rem;
+}
+
+.size6xl {
+  width: 100%;
+  max-width: 72rem;
+}
+
+.sizeFull {
+  width: 100%;
+  max-width: 100vw;
+  min-height: 100vh;
+  margin: 0;
+  border-radius: 0;
+}
+
+.header {
+  padding: calc(var(--spacing) * 4) calc(var(--spacing) * 6);
+  padding-bottom: calc(var(--spacing) * 2);
+  font-size: var(--font-size-lg);
+  font-weight: 600;
+}
+
+.body {
+  padding: calc(var(--spacing) * 2) calc(var(--spacing) * 6);
+  flex: 1;
+  overflow-y: auto;
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: calc(var(--spacing) * 3);
+  padding: calc(var(--spacing) * 4) calc(var(--spacing) * 6);
+  padding-top: calc(var(--spacing) * 2);
+}
+
+.closeButton {
+  position: absolute;
+  top: calc(var(--spacing) * 2);
+  right: calc(var(--spacing) * 3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.closeButton:hover {
+  background-color: var(--color-gray-100);
+}
+
+.closeButton:focus {
+  outline: 2px solid var(--color-primary-500);
+  outline-offset: 2px;
+}

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,0 +1,245 @@
+import {
+  forwardRef,
+  HTMLAttributes,
+  ReactNode,
+  createContext,
+  useContext,
+  useEffect,
+  useCallback,
+  MouseEvent,
+} from 'react';
+import { createPortal } from 'react-dom';
+import styles from './Modal.module.css';
+
+export type ModalSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl' | '5xl' | '6xl' | 'full';
+
+export interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  children?: ReactNode;
+  size?: ModalSize;
+  isCentered?: boolean;
+  closeOnOverlayClick?: boolean;
+  closeOnEsc?: boolean;
+}
+
+export interface ModalOverlayProps extends HTMLAttributes<HTMLDivElement> {}
+
+export interface ModalContentProps extends HTMLAttributes<HTMLDivElement> {
+  children?: ReactNode;
+}
+
+export interface ModalHeaderProps extends HTMLAttributes<HTMLDivElement> {
+  children?: ReactNode;
+}
+
+export interface ModalBodyProps extends HTMLAttributes<HTMLDivElement> {
+  children?: ReactNode;
+}
+
+export interface ModalFooterProps extends HTMLAttributes<HTMLDivElement> {
+  children?: ReactNode;
+}
+
+export interface ModalCloseButtonProps extends HTMLAttributes<HTMLButtonElement> {}
+
+interface ModalContextValue {
+  onClose: () => void;
+  closeOnOverlayClick: boolean;
+  size: ModalSize;
+  isCentered: boolean;
+}
+
+const ModalContext = createContext<ModalContextValue | null>(null);
+
+const useModalContext = (): ModalContextValue => {
+  const context = useContext(ModalContext);
+  if (!context) {
+    throw new Error('Modal compound components must be used within Modal');
+  }
+  return context;
+};
+
+const sizeClassMap: Record<ModalSize, string> = {
+  xs: styles.sizeXs,
+  sm: styles.sizeSm,
+  md: styles.sizeMd,
+  lg: styles.sizeLg,
+  xl: styles.sizeXl,
+  '2xl': styles.size2xl,
+  '3xl': styles.size3xl,
+  '4xl': styles.size4xl,
+  '5xl': styles.size5xl,
+  '6xl': styles.size6xl,
+  full: styles.sizeFull,
+};
+
+const Modal = ({
+  isOpen,
+  onClose,
+  children,
+  size = 'md',
+  isCentered = false,
+  closeOnOverlayClick = true,
+  closeOnEsc = true,
+}: ModalProps) => {
+  const handleKeyDown = useCallback(
+    (event: globalThis.KeyboardEvent) => {
+      if (event.key === 'Escape' && closeOnEsc) {
+        onClose();
+      }
+    },
+    [closeOnEsc, onClose]
+  );
+
+  useEffect(() => {
+    if (isOpen) {
+      document.addEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = 'hidden';
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = '';
+    };
+  }, [isOpen, handleKeyDown]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const contextValue: ModalContextValue = {
+    onClose,
+    closeOnOverlayClick,
+    size,
+    isCentered,
+  };
+
+  return createPortal(
+    <ModalContext.Provider value={contextValue}>
+      <div className={styles.modalRoot} role="dialog" aria-modal="true">
+        {children}
+      </div>
+    </ModalContext.Provider>,
+    document.body
+  );
+};
+
+Modal.displayName = 'Modal';
+
+const ModalOverlay = forwardRef<HTMLDivElement, ModalOverlayProps>(
+  ({ className, onClick, ...props }, ref) => {
+    const { onClose, closeOnOverlayClick } = useModalContext();
+
+    const handleClick = (event: MouseEvent<HTMLDivElement>) => {
+      if (closeOnOverlayClick && event.target === event.currentTarget) {
+        onClose();
+      }
+      onClick?.(event);
+    };
+
+    const classNames = [styles.overlay, className].filter(Boolean).join(' ');
+
+    return <div ref={ref} className={classNames} onClick={handleClick} {...props} />;
+  }
+);
+
+ModalOverlay.displayName = 'ModalOverlay';
+
+const ModalContent = forwardRef<HTMLDivElement, ModalContentProps>(
+  ({ children, className, ...props }, ref) => {
+    const { size, isCentered } = useModalContext();
+
+    const classNames = [
+      styles.content,
+      sizeClassMap[size],
+      isCentered && styles.centered,
+      className,
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    return (
+      <div ref={ref} className={classNames} {...props}>
+        {children}
+      </div>
+    );
+  }
+);
+
+ModalContent.displayName = 'ModalContent';
+
+const ModalHeader = forwardRef<HTMLDivElement, ModalHeaderProps>(
+  ({ children, className, ...props }, ref) => {
+    const classNames = [styles.header, className].filter(Boolean).join(' ');
+
+    return (
+      <div ref={ref} className={classNames} {...props}>
+        {children}
+      </div>
+    );
+  }
+);
+
+ModalHeader.displayName = 'ModalHeader';
+
+const ModalBody = forwardRef<HTMLDivElement, ModalBodyProps>(
+  ({ children, className, ...props }, ref) => {
+    const classNames = [styles.body, className].filter(Boolean).join(' ');
+
+    return (
+      <div ref={ref} className={classNames} {...props}>
+        {children}
+      </div>
+    );
+  }
+);
+
+ModalBody.displayName = 'ModalBody';
+
+const ModalFooter = forwardRef<HTMLDivElement, ModalFooterProps>(
+  ({ children, className, ...props }, ref) => {
+    const classNames = [styles.footer, className].filter(Boolean).join(' ');
+
+    return (
+      <div ref={ref} className={classNames} {...props}>
+        {children}
+      </div>
+    );
+  }
+);
+
+ModalFooter.displayName = 'ModalFooter';
+
+const ModalCloseButton = forwardRef<HTMLButtonElement, ModalCloseButtonProps>(
+  ({ className, onClick, ...props }, ref) => {
+    const { onClose } = useModalContext();
+
+    const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+      onClose();
+      onClick?.(event);
+    };
+
+    const classNames = [styles.closeButton, className].filter(Boolean).join(' ');
+
+    return (
+      <button
+        ref={ref}
+        type="button"
+        aria-label="Close"
+        className={classNames}
+        onClick={handleClick}
+        {...props}
+      >
+        <svg viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" strokeWidth="2" fill="none">
+          <path d="M18 6L6 18M6 6l12 12" />
+        </svg>
+      </button>
+    );
+  }
+);
+
+ModalCloseButton.displayName = 'ModalCloseButton';
+
+export default Modal;
+export { ModalOverlay, ModalContent, ModalHeader, ModalBody, ModalFooter, ModalCloseButton };

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -13,6 +13,7 @@ export { default as AvatarGroup } from './AvatarGroup';
 export { default as AvatarBadge } from './AvatarBadge';
 export { default as Badge } from './Badge';
 export { default as Alert, AlertIcon, AlertTitle, AlertDescription } from './Alert';
+export { default as Modal, ModalOverlay, ModalContent, ModalHeader, ModalBody, ModalFooter, ModalCloseButton } from './Modal';
 
 export { default as Input } from './Input';
 export { default as InputGroup } from './InputGroup';
@@ -87,3 +88,5 @@ export type { AvatarBadgeProps } from './AvatarBadge';
 export type { BadgeVariant, BadgeColorScheme, BadgeProps } from './Badge';
 
 export type { AlertStatus, AlertProps, AlertIconProps, AlertTitleProps, AlertDescriptionProps } from './Alert';
+
+export type { ModalSize, ModalProps, ModalOverlayProps, ModalContentProps, ModalHeaderProps, ModalBodyProps, ModalFooterProps, ModalCloseButtonProps } from './Modal';

--- a/src/pages/compare/Modal.tsx
+++ b/src/pages/compare/Modal.tsx
@@ -1,0 +1,465 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Box as ChakraBox,
+  Modal as ChakraModal,
+  ModalOverlay as ChakraModalOverlay,
+  ModalContent as ChakraModalContent,
+  ModalHeader as ChakraModalHeader,
+  ModalBody as ChakraModalBody,
+  ModalFooter as ChakraModalFooter,
+  ModalCloseButton as ChakraModalCloseButton,
+  Button as ChakraButton,
+  SimpleGrid as ChakraSimpleGrid,
+  Text,
+  Heading,
+  VStack as ChakraVStack,
+  useDisclosure,
+} from '@chakra-ui/react';
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  ModalCloseButton,
+  Button,
+  VStack,
+} from '../../components/ui';
+
+const CompareSection = ({
+  title,
+  chakraVersion,
+  newVersion,
+}: {
+  title: string;
+  chakraVersion: React.ReactNode;
+  newVersion: React.ReactNode;
+}) => (
+  <ChakraBox mb={8}>
+    <Heading size="md" mb={4}>{title}</Heading>
+    <ChakraSimpleGrid columns={2} spacing={4}>
+      <ChakraBox>
+        <Text fontWeight="bold" mb={2} color="blue.600">Chakra UI</Text>
+        <ChakraBox border="1px" borderColor="gray.200" p={4} borderRadius="md">
+          {chakraVersion}
+        </ChakraBox>
+      </ChakraBox>
+      <ChakraBox>
+        <Text fontWeight="bold" mb={2} color="green.600">New (CSS Modules)</Text>
+        <ChakraBox border="1px" borderColor="gray.200" p={4} borderRadius="md">
+          {newVersion}
+        </ChakraBox>
+      </ChakraBox>
+    </ChakraSimpleGrid>
+  </ChakraBox>
+);
+
+const BasicModalDemo = () => {
+  const chakraDisclosure = useDisclosure();
+  const [isNewOpen, setIsNewOpen] = useState(false);
+
+  return (
+    <CompareSection
+      title="Modal - Basic"
+      chakraVersion={
+        <>
+          <ChakraButton onClick={chakraDisclosure.onOpen}>Open Modal</ChakraButton>
+          <ChakraModal isOpen={chakraDisclosure.isOpen} onClose={chakraDisclosure.onClose}>
+            <ChakraModalOverlay />
+            <ChakraModalContent>
+              <ChakraModalHeader>Modal Title</ChakraModalHeader>
+              <ChakraModalCloseButton />
+              <ChakraModalBody>
+                <Text>This is the modal body content.</Text>
+              </ChakraModalBody>
+              <ChakraModalFooter>
+                <ChakraButton variant="ghost" mr={3} onClick={chakraDisclosure.onClose}>
+                  Cancel
+                </ChakraButton>
+                <ChakraButton colorScheme="blue">Save</ChakraButton>
+              </ChakraModalFooter>
+            </ChakraModalContent>
+          </ChakraModal>
+        </>
+      }
+      newVersion={
+        <>
+          <Button onClick={() => setIsNewOpen(true)}>Open Modal</Button>
+          <Modal isOpen={isNewOpen} onClose={() => setIsNewOpen(false)}>
+            <ModalOverlay />
+            <ModalContent>
+              <ModalHeader>Modal Title</ModalHeader>
+              <ModalCloseButton />
+              <ModalBody>
+                <span>This is the modal body content.</span>
+              </ModalBody>
+              <ModalFooter>
+                <Button variant="ghost" onClick={() => setIsNewOpen(false)}>
+                  Cancel
+                </Button>
+                <Button colorScheme="blue">Save</Button>
+              </ModalFooter>
+            </ModalContent>
+          </Modal>
+        </>
+      }
+    />
+  );
+};
+
+const SizeModalDemo = () => {
+  const [chakraSize, setChakraSize] = useState<'xs' | 'sm' | 'md' | 'lg' | 'xl'>('md');
+  const chakraDisclosure = useDisclosure();
+  const [isNewOpen, setIsNewOpen] = useState(false);
+  const [newSize, setNewSize] = useState<'xs' | 'sm' | 'md' | 'lg' | 'xl'>('md');
+
+  const sizes: Array<'xs' | 'sm' | 'md' | 'lg' | 'xl'> = ['xs', 'sm', 'md', 'lg', 'xl'];
+
+  return (
+    <CompareSection
+      title="Modal - Different Sizes"
+      chakraVersion={
+        <ChakraVStack spacing={2} align="start">
+          {sizes.map((size) => (
+            <ChakraButton
+              key={size}
+              size="sm"
+              onClick={() => {
+                setChakraSize(size);
+                chakraDisclosure.onOpen();
+              }}
+            >
+              Open {size.toUpperCase()}
+            </ChakraButton>
+          ))}
+          <ChakraModal isOpen={chakraDisclosure.isOpen} onClose={chakraDisclosure.onClose} size={chakraSize}>
+            <ChakraModalOverlay />
+            <ChakraModalContent>
+              <ChakraModalHeader>Size: {chakraSize}</ChakraModalHeader>
+              <ChakraModalCloseButton />
+              <ChakraModalBody>
+                <Text>This modal has size=&quot;{chakraSize}&quot;</Text>
+              </ChakraModalBody>
+              <ChakraModalFooter>
+                <ChakraButton onClick={chakraDisclosure.onClose}>Close</ChakraButton>
+              </ChakraModalFooter>
+            </ChakraModalContent>
+          </ChakraModal>
+        </ChakraVStack>
+      }
+      newVersion={
+        <VStack spacing={2} align="start">
+          {sizes.map((size) => (
+            <Button
+              key={size}
+              size="sm"
+              onClick={() => {
+                setNewSize(size);
+                setIsNewOpen(true);
+              }}
+            >
+              Open {size.toUpperCase()}
+            </Button>
+          ))}
+          <Modal isOpen={isNewOpen} onClose={() => setIsNewOpen(false)} size={newSize}>
+            <ModalOverlay />
+            <ModalContent>
+              <ModalHeader>Size: {newSize}</ModalHeader>
+              <ModalCloseButton />
+              <ModalBody>
+                <span>This modal has size=&quot;{newSize}&quot;</span>
+              </ModalBody>
+              <ModalFooter>
+                <Button onClick={() => setIsNewOpen(false)}>Close</Button>
+              </ModalFooter>
+            </ModalContent>
+          </Modal>
+        </VStack>
+      }
+    />
+  );
+};
+
+const CenteredModalDemo = () => {
+  const chakraDisclosure = useDisclosure();
+  const [isNewOpen, setIsNewOpen] = useState(false);
+
+  return (
+    <CompareSection
+      title="Modal - Centered"
+      chakraVersion={
+        <>
+          <ChakraButton onClick={chakraDisclosure.onOpen}>Open Centered Modal</ChakraButton>
+          <ChakraModal isOpen={chakraDisclosure.isOpen} onClose={chakraDisclosure.onClose} isCentered>
+            <ChakraModalOverlay />
+            <ChakraModalContent>
+              <ChakraModalHeader>Centered Modal</ChakraModalHeader>
+              <ChakraModalCloseButton />
+              <ChakraModalBody>
+                <Text>This modal is vertically centered.</Text>
+              </ChakraModalBody>
+              <ChakraModalFooter>
+                <ChakraButton onClick={chakraDisclosure.onClose}>Close</ChakraButton>
+              </ChakraModalFooter>
+            </ChakraModalContent>
+          </ChakraModal>
+        </>
+      }
+      newVersion={
+        <>
+          <Button onClick={() => setIsNewOpen(true)}>Open Centered Modal</Button>
+          <Modal isOpen={isNewOpen} onClose={() => setIsNewOpen(false)} isCentered>
+            <ModalOverlay />
+            <ModalContent>
+              <ModalHeader>Centered Modal</ModalHeader>
+              <ModalCloseButton />
+              <ModalBody>
+                <span>This modal is vertically centered.</span>
+              </ModalBody>
+              <ModalFooter>
+                <Button onClick={() => setIsNewOpen(false)}>Close</Button>
+              </ModalFooter>
+            </ModalContent>
+          </Modal>
+        </>
+      }
+    />
+  );
+};
+
+const NoOverlayClickModalDemo = () => {
+  const chakraDisclosure = useDisclosure();
+  const [isNewOpen, setIsNewOpen] = useState(false);
+
+  return (
+    <CompareSection
+      title="Modal - closeOnOverlayClick=false"
+      chakraVersion={
+        <>
+          <ChakraButton onClick={chakraDisclosure.onOpen}>Open Modal (No Overlay Close)</ChakraButton>
+          <ChakraModal
+            isOpen={chakraDisclosure.isOpen}
+            onClose={chakraDisclosure.onClose}
+            closeOnOverlayClick={false}
+          >
+            <ChakraModalOverlay />
+            <ChakraModalContent>
+              <ChakraModalHeader>Cannot Close by Overlay</ChakraModalHeader>
+              <ChakraModalCloseButton />
+              <ChakraModalBody>
+                <Text>Click outside will not close this modal.</Text>
+              </ChakraModalBody>
+              <ChakraModalFooter>
+                <ChakraButton onClick={chakraDisclosure.onClose}>Close</ChakraButton>
+              </ChakraModalFooter>
+            </ChakraModalContent>
+          </ChakraModal>
+        </>
+      }
+      newVersion={
+        <>
+          <Button onClick={() => setIsNewOpen(true)}>Open Modal (No Overlay Close)</Button>
+          <Modal
+            isOpen={isNewOpen}
+            onClose={() => setIsNewOpen(false)}
+            closeOnOverlayClick={false}
+          >
+            <ModalOverlay />
+            <ModalContent>
+              <ModalHeader>Cannot Close by Overlay</ModalHeader>
+              <ModalCloseButton />
+              <ModalBody>
+                <span>Click outside will not close this modal.</span>
+              </ModalBody>
+              <ModalFooter>
+                <Button onClick={() => setIsNewOpen(false)}>Close</Button>
+              </ModalFooter>
+            </ModalContent>
+          </Modal>
+        </>
+      }
+    />
+  );
+};
+
+const FormModalDemo = () => {
+  const chakraDisclosure = useDisclosure();
+  const [isNewOpen, setIsNewOpen] = useState(false);
+
+  return (
+    <CompareSection
+      title="Modal - Form Use Case"
+      chakraVersion={
+        <>
+          <ChakraButton onClick={chakraDisclosure.onOpen}>Open Form Modal</ChakraButton>
+          <ChakraModal isOpen={chakraDisclosure.isOpen} onClose={chakraDisclosure.onClose} size="lg">
+            <ChakraModalOverlay />
+            <ChakraModalContent>
+              <ChakraModalHeader>Create New Task</ChakraModalHeader>
+              <ChakraModalCloseButton />
+              <ChakraModalBody>
+                <ChakraVStack spacing={4} align="stretch">
+                  <ChakraBox>
+                    <Text fontWeight="medium" mb={1}>Task Name</Text>
+                    <input
+                      type="text"
+                      placeholder="Enter task name"
+                      style={{
+                        width: '100%',
+                        padding: '8px 12px',
+                        border: '1px solid #E2E8F0',
+                        borderRadius: '6px',
+                      }}
+                    />
+                  </ChakraBox>
+                  <ChakraBox>
+                    <Text fontWeight="medium" mb={1}>Description</Text>
+                    <textarea
+                      placeholder="Enter description"
+                      rows={3}
+                      style={{
+                        width: '100%',
+                        padding: '8px 12px',
+                        border: '1px solid #E2E8F0',
+                        borderRadius: '6px',
+                        resize: 'vertical',
+                      }}
+                    />
+                  </ChakraBox>
+                </ChakraVStack>
+              </ChakraModalBody>
+              <ChakraModalFooter>
+                <ChakraButton variant="ghost" mr={3} onClick={chakraDisclosure.onClose}>
+                  Cancel
+                </ChakraButton>
+                <ChakraButton colorScheme="blue">Create Task</ChakraButton>
+              </ChakraModalFooter>
+            </ChakraModalContent>
+          </ChakraModal>
+        </>
+      }
+      newVersion={
+        <>
+          <Button onClick={() => setIsNewOpen(true)}>Open Form Modal</Button>
+          <Modal isOpen={isNewOpen} onClose={() => setIsNewOpen(false)} size="lg">
+            <ModalOverlay />
+            <ModalContent>
+              <ModalHeader>Create New Task</ModalHeader>
+              <ModalCloseButton />
+              <ModalBody>
+                <VStack spacing={4} align="stretch">
+                  <div>
+                    <span style={{ fontWeight: 500, display: 'block', marginBottom: '4px' }}>Task Name</span>
+                    <input
+                      type="text"
+                      placeholder="Enter task name"
+                      style={{
+                        width: '100%',
+                        padding: '8px 12px',
+                        border: '1px solid #E2E8F0',
+                        borderRadius: '6px',
+                      }}
+                    />
+                  </div>
+                  <div>
+                    <span style={{ fontWeight: 500, display: 'block', marginBottom: '4px' }}>Description</span>
+                    <textarea
+                      placeholder="Enter description"
+                      rows={3}
+                      style={{
+                        width: '100%',
+                        padding: '8px 12px',
+                        border: '1px solid #E2E8F0',
+                        borderRadius: '6px',
+                        resize: 'vertical',
+                      }}
+                    />
+                  </div>
+                </VStack>
+              </ModalBody>
+              <ModalFooter>
+                <Button variant="ghost" onClick={() => setIsNewOpen(false)}>
+                  Cancel
+                </Button>
+                <Button colorScheme="blue">Create Task</Button>
+              </ModalFooter>
+            </ModalContent>
+          </Modal>
+        </>
+      }
+    />
+  );
+};
+
+const ConfirmModalDemo = () => {
+  const chakraDisclosure = useDisclosure();
+  const [isNewOpen, setIsNewOpen] = useState(false);
+
+  return (
+    <CompareSection
+      title="Modal - Confirmation Dialog"
+      chakraVersion={
+        <>
+          <ChakraButton colorScheme="red" onClick={chakraDisclosure.onOpen}>Delete Item</ChakraButton>
+          <ChakraModal isOpen={chakraDisclosure.isOpen} onClose={chakraDisclosure.onClose} size="sm" isCentered>
+            <ChakraModalOverlay />
+            <ChakraModalContent>
+              <ChakraModalHeader>Confirm Delete</ChakraModalHeader>
+              <ChakraModalCloseButton />
+              <ChakraModalBody>
+                <Text>Are you sure you want to delete this item? This action cannot be undone.</Text>
+              </ChakraModalBody>
+              <ChakraModalFooter>
+                <ChakraButton variant="ghost" mr={3} onClick={chakraDisclosure.onClose}>
+                  Cancel
+                </ChakraButton>
+                <ChakraButton colorScheme="red" onClick={chakraDisclosure.onClose}>Delete</ChakraButton>
+              </ChakraModalFooter>
+            </ChakraModalContent>
+          </ChakraModal>
+        </>
+      }
+      newVersion={
+        <>
+          <Button colorScheme="red" onClick={() => setIsNewOpen(true)}>Delete Item</Button>
+          <Modal isOpen={isNewOpen} onClose={() => setIsNewOpen(false)} size="sm" isCentered>
+            <ModalOverlay />
+            <ModalContent>
+              <ModalHeader>Confirm Delete</ModalHeader>
+              <ModalCloseButton />
+              <ModalBody>
+                <span>Are you sure you want to delete this item? This action cannot be undone.</span>
+              </ModalBody>
+              <ModalFooter>
+                <Button variant="ghost" onClick={() => setIsNewOpen(false)}>
+                  Cancel
+                </Button>
+                <Button colorScheme="red" onClick={() => setIsNewOpen(false)}>Delete</Button>
+              </ModalFooter>
+            </ModalContent>
+          </Modal>
+        </>
+      }
+    />
+  );
+};
+
+const ModalComparePage = () => {
+  return (
+    <ChakraBox p={8} maxW="1400px" mx="auto">
+      <Heading mb={8}>Modal Components Comparison</Heading>
+
+      <BasicModalDemo />
+      <SizeModalDemo />
+      <CenteredModalDemo />
+      <NoOverlayClickModalDemo />
+      <FormModalDemo />
+      <ConfirmModalDemo />
+    </ChakraBox>
+  );
+};
+
+export default ModalComparePage;


### PR DESCRIPTION
## Summary
- Modal, ModalOverlay, ModalContent, ModalHeader, ModalBody, ModalFooter, ModalCloseButton コンポーネントを追加
- CSS Modulesで実装
- 比較ページ追加

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)